### PR TITLE
Make touch detect work also on Android

### DIFF
--- a/lib/ext/mobile.js
+++ b/lib/ext/mobile.js
@@ -10,11 +10,10 @@ if (flowplayer.support.touch) {
       }
 
       // fake mouseover effect with click
-      !isAndroid && root.one("touchstart", function() {
-         player.toggle();
+      root.one("touchstart", function() {
+         isAndroid && player.toggle();
 
-      });
-      root.bind("touchstart", function(e) {
+      }).bind("touchstart", function(e) {
          if (player.playing && !root.hasClass("is-mouseover")) {
             root.addClass("is-mouseover");
             return false;

--- a/lib/ext/support.js
+++ b/lib/ext/support.js
@@ -17,7 +17,7 @@
       subtitles: !!video.addTextTrack,
       fullscreen: typeof document.webkitCancelFullScreen == 'function' || document.mozFullScreenEnabled,
       inlineBlock: !(browser.msie && browser.version < 8),
-      touch: typeof Touch == 'object',
+      touch: ('ontouchstart' in window),
       dataload: !IS_IPAD || IPAD_VER >= 6,
       zeropreload: !IS_IE && !IS_ANDROID, // IE supports only preload=metadata
       volume: !IS_IPAD && !IS_ANDROID,


### PR DESCRIPTION
Android doesn't have window.Touch so I think checking for touchstart would
be as good. Also we can't trigger the additional player.toggle() as android
starts to play without it so it will just pause the video immediately.
