### PR TITLE
inverse concat and min make targets (fix #114)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ flash:
 	@ cd $(DIST) && $(FLASH_COMPILE) -output flowplayer.swf Flowplayer.as && rm Flowplayer.as logo.*
 
 
-zip: concat min skins flash
+zip: min concat skins flash
 	@ cp index.html $(DIST)
 	@ cp LICENSE.md $(DIST)
 	@ rm -f $(DIST)/flowplayer.zip


### PR DESCRIPTION
"concat" builds raw and appends branding, then "min" uglify raw+branding and appends branding again
