### PR TITLE
Issue #123: always adapt size of flash object

### DIFF
--- a/lib/engine/flash.js
+++ b/lib/engine/flash.js
@@ -143,6 +143,34 @@ flowplayer.engine.flash = function(player, root) {
 
    });
 
+   var origH = root.height(),
+      origW = root.width();
+
+   // handle Flash object aspect ratio
+   player.bind("ready fullscreen fullscreen-exit", function() {
+      var fs = player.isFullscreen,
+         truefs = fs && FS_SUPPORT,
+         screenW = fs ? (truefs ? screen.availWidth : $(window).width()) : origW,
+         screenH = fs ? (truefs ? screen.availHeight : $(window).height()) : origH,
+			hmargin = truefs ? screen.width - screen.availWidth : 0,
+			vmargin = truefs ? screen.height - screen.availHeight : 0,
+         aspectratio = player.video.width / player.video.height,
+         dataratio = player.video.height / player.video.width,
+         objheight = Math.max(dataratio * screenW),
+         objwidth = Math.max(aspectratio * screenH);
+
+      objheight = objheight > screenH ? objwidth * dataratio : objheight;
+      objwidth = objwidth > screenW ? objheight * aspectratio : objwidth;
+
+      $("object", root).css({
+         width: objwidth,
+         height: objheight,
+         marginTop:  (screenH + vmargin - objheight) / 2,
+         marginLeft: (screenW + hmargin - objwidth) / 2
+      });
+
+   });
+
    return engine;
 
 };

--- a/lib/ext/fullscreen.js
+++ b/lib/ext/fullscreen.js
@@ -61,33 +61,5 @@ flowplayer(function(player, root) {
       player.isFullscreen = false;
    });
 
-   var origH = root.height(),
-      origW = root.width();
-
-   // handle Flash object aspect ratio on fullscreen
-   player.bind("fullscreen", function() {
-
-      var screenW = FS_SUPPORT ? screen.width : $(window).width(),
-         screenH = FS_SUPPORT ? screen.height : $(window).height(),
-         ratio = player.video.height / player.video.width,
-         dim = ratio > 0.5 ? screenH * (1 / ratio) : screenW * ratio;
-
-      $("object", root).css(ratio > 0.5 ?
-         { width: dim, marginLeft: (screenW - dim) / 2, height: '100%' } :
-         { height: dim, marginTop: (screenH - dim - 20) / 2, width: '100%' }
-      );
-
-
-   }).bind("fullscreen-exit", function() {
-      var ie7 = $.browser.msie && $.browser.version < 8,
-         ratio = player.video.height / player.video.width;
-
-      $("object", root).css(ratio > 0.5 ?
-         { width: ie7 ? origW : '', height: ie7 ? origH : '', marginLeft: '' } :
-         { height: ie7 ? origH : '', width: ie7 ? origW : '', marginTop: '' }
-      );
-
-   });
-
 });
 


### PR DESCRIPTION
- move into flash engine, thereby tying the event to flash only.
- do not simply fill container in normal mode, especially important
  with playlists containing clips in differing aspect ratios.
- fix issue #126 by a different calculation method.
- reduce cutoff in true fullscreen mode by using screen.availWidth
  and screen.availHeight; subtract screen.width and screen.height
  instead of assuming a negative topMargin of 20.
- omit special casing of ie7 until clarification of why it was only
  applied in fullscreen-exit.
