### PR TITLE
Set pause property after calling stream.pause in Stop handler - #139

### DIFF
--- a/lib/as/Flowplayer.as
+++ b/lib/as/Flowplayer.as
@@ -301,7 +301,7 @@ package {
                         case "NetStream.Play.Stop":
                            finished = true;
                            if (conf.loop) stream.seek(0);
-                           else { fire(Flowplayer.FINISH, null); stream.pause(); }
+                           else { fire(Flowplayer.FINISH, null); stream.pause(); paused = true; }
                            break;
 
                         case "NetStream.Buffer.Full":


### PR DESCRIPTION
Addressing issue #139

Setting the pause property allows the next call to "resume" replay the stream.
