### PR TITLE
flash: retrieve hostname from location, not top.location (#200, #201)

### DIFF
--- a/lib/engine/flash.js
+++ b/lib/engine/flash.js
@@ -45,7 +45,7 @@ flowplayer.engine.flash = function(player, root) {
             callbackId = "fp" + ("" + Math.random()).slice(3, 15);
 
             var opts = {
-               hostname: conf.embedded ? conf.hostname : top.location.hostname,
+               hostname: conf.embedded ? conf.hostname : location.hostname,
                url: url,
                callback: "jQuery."+ callbackId
             };


### PR DESCRIPTION
top.location is wrong licensing- and functionality-wise.
- license is validated against the _src_ of the iframe, i.e.
  location.hostname
- top.location.hostname is not available in iframes for security reasons
  in Firefox and Opera and stalls the player in loading state

May also solve the elusive #135.
