### PR TITLE
flash fullscreen hotfix (#217)

### DIFF
--- a/lib/engine/flash.js
+++ b/lib/engine/flash.js
@@ -151,7 +151,7 @@ flowplayer.engine.flash = function(player, root) {
       origW = root.width();
 
    // handle Flash object aspect ratio
-   player.bind("ready fullscreen fullscreen-exit", function() {
+   player.bind("ready fullscreen fullscreen-exit", function(e) {
       if (player.conf.flashfit || /full/.test(e.type)) {
 
          var fs = player.isFullscreen,


### PR DESCRIPTION
In ef01d81846f629d2e650eb79eeb7453b49cd5c14 a change to one line was
fatally omitted, now causing an error every time fullscreen is toggled
in flash mode.
