### PR TITLE
engine.flash: fix a missing callback argument

### DIFF
--- a/lib/engine/flash.js
+++ b/lib/engine/flash.js
@@ -151,7 +151,7 @@ flowplayer.engine.flash = function(player, root) {
       origW = root.width();
 
    // handle Flash object aspect ratio
-   player.bind("ready fullscreen fullscreen-exit", function() {
+   player.bind("ready fullscreen fullscreen-exit", function(e) {
       if (player.conf.flashfit || /full/.test(e.type)) {
 
          var fs = player.isFullscreen,


### PR DESCRIPTION
Got JS error "ReferenceError: e is not defined" next line.
