### PR TITLE
Set storage.volume immediately when api.volume() is called

### DIFF
--- a/lib/flowplayer.js
+++ b/lib/flowplayer.js
@@ -233,7 +233,12 @@ $.fn.flowplayer = function(opts, callback) {
          },
 
          volume: function(level) {
-            if (api.ready) engine.volume(Math.min(Math.max(level, 0), 1));
+            if (api.ready) {
+              level = Math.min(Math.max(level, 0), 1);
+              storage.volume = level;
+              engine.volume(level);
+            }
+            
             return api;
          },
 


### PR DESCRIPTION
Fixes issue #231
