### PR TITLE
Set api.loading as false when event default is prevented

### DIFF
--- a/lib/flowplayer.js
+++ b/lib/flowplayer.js
@@ -160,6 +160,8 @@ $.fn.flowplayer = function(opts, callback) {
                   // callback
                   if ($.isFunction(video)) callback = video;
                   if (callback) root.one("ready", callback);
+               } else {
+                  api.loading = false;
                }
             }
 


### PR DESCRIPTION
People might want to do stuff on load-event and prevent it and then call api.load() again. That's why we need to set api.loading to false.
