### PR TITLE
Fixed Level 3 signed URLs (or URLs with a Query-String)

### DIFF
--- a/lib/ext/resolve.js
+++ b/lib/ext/resolve.js
@@ -1,5 +1,4 @@
-
-var TYPE_RE = /.(\w{3,4})$/i;
+var TYPE_RE = /\.(\w{3,4})(\?.*)?$/i;
 
 function parseSource(el) {
 
@@ -48,7 +47,7 @@ function URLResolver(videoTag) {
             if (source.type != 'flash') {
                video.sources.push({
                   type: source.type,
-                  src: video.src.replace(TYPE_RE, "") + "." + source.suffix
+                  src: video.src.replace(TYPE_RE, "." + source.suffix + "$2")
                });
             }
          });


### PR DESCRIPTION
URLs with Query-Strings (e.g. signed URLs) couldn't be loaded by the load-Method.
