### PR TITLE
Don't fallback to native controls for android firefox (#146)

### DIFF
--- a/lib/flowplayer.js
+++ b/lib/flowplayer.js
@@ -8,14 +8,12 @@ $(function() {
 
 var instances = [],
    extensions = [],
-   UA = navigator.userAgent,
-   use_native = /Android/.test(UA) && /Firefox/.test(UA);
+   UA = window.navigator.userAgent;
 
 
 /* flowplayer()  */
 window.flowplayer = function(fn) {
-   return use_native ? 0 :
-      $.isFunction(fn) ? extensions.push(fn) :
+   return $.isFunction(fn) ? extensions.push(fn) :
       typeof fn == 'number' || fn === undefined ? instances[fn || 0] :
       $(fn).data("flowplayer");
 };
@@ -91,11 +89,6 @@ $.extend(flowplayer, {
    }
 
 });
-
-// smartphones simply use native controls
-if (use_native) {
-   return $(function() { $("video").attr("controls", "controls"); });
-}
 
 // keep track of players
 var playerCount = 0;


### PR DESCRIPTION
Seems current flowplayer is fully compatible with current android firefox
