### PR TITLE
Native fullscreen support

### DIFF
--- a/lib/ext/fullscreen.js
+++ b/lib/ext/fullscreen.js
@@ -3,12 +3,13 @@ var VENDOR = $.browser.mozilla ? "moz": "webkit",
    FS_ENTER = "fullscreen",
    FS_EXIT = "fullscreen-exit",
    FULL_PLAYER,
-   FS_SUPPORT = flowplayer.support.fullscreen;
+   FS_SUPPORT = flowplayer.support.fullscreen,
+   FS_NATIVE_SUPPORT = typeof document.exitFullscreen == 'function';
 
 
 // esc button
-$(document).bind(VENDOR + "fullscreenchange", function(e) {
-   var el = $(document.webkitCurrentFullScreenElement || document.mozFullScreenElement);
+$(document).bind(FS_NATIVE_SUPPORT ? "fullscreenchange" : VENDOR + "fullscreenchange", function(e) {
+   var el = $(document.webkitCurrentFullScreenElement || document.mozFullScreenElement || document.fullscreenElement);
 
    if (el.length) {
       FULL_PLAYER = el.trigger(FS_ENTER, [el]);
@@ -40,12 +41,20 @@ flowplayer(function(player, root) {
       if (FS_SUPPORT) {
 
          if (flag) {
-            root[0][VENDOR + 'RequestFullScreen'](
-               flowplayer.support.fullscreen_keyboard ? Element.ALLOW_KEYBOARD_INPUT : undefined
-            );
+            if (FS_NATIVE_SUPPORT) {
+              root[0].requestFullscreen();
+            } else {
+              root[0][VENDOR + 'RequestFullScreen'](
+                 flowplayer.support.fullscreen_keyboard ? Element.ALLOW_KEYBOARD_INPUT : undefined
+              );
+            }
 
          } else {
-            document[VENDOR + 'CancelFullScreen']();
+            if (FS_NATIVE_SUPPORT) {
+              document.exitFullscreen();
+            } else {
+              document[VENDOR + 'CancelFullScreen']();
+            }
          }
 
       } else {

--- a/lib/ext/support.js
+++ b/lib/ext/support.js
@@ -19,7 +19,7 @@
       video: !!video.canPlayType,
       subtitles: !!video.addTextTrack,
       fullscreen: typeof document.webkitCancelFullScreen == 'function'
-         && !/Mac OS X 10_5.+Version\/5\.0\.\d Safari/.test(UA) || document.mozFullScreenEnabled,
+         && !/Mac OS X 10_5.+Version\/5\.0\.\d Safari/.test(UA) || document.mozFullScreenEnabled || typeof document.exitFullscreen == 'function',
       fullscreen_keyboard: !browser.safari || browser.version > "536",
       inlineBlock: !(IS_IE && browser.version < 8),
       touch: ('ontouchstart' in window),


### PR DESCRIPTION
Native fullscreen api support according to http://www.w3.org/TR/fullscreen/.

Also this pull request allow last Opera normal fullscreen mode.
