### PR TITLE
Don't pause on the NetStream.Play.Stop event, it causes the video to be ...

### DIFF
--- a/lib/as/Flowplayer.as
+++ b/lib/as/Flowplayer.as
@@ -322,7 +322,7 @@ public class Flowplayer extends Sprite {
                         case "NetStream.Play.Stop":
                            finished = true;
                            if (conf.loop) stream.seek(0);
-                           else { fire(Flowplayer.FINISH, null); stream.pause(); paused = true; }
+                           else { fire(Flowplayer.FINISH, null); paused = true; }
                            break;
 
                         case "NetStream.Buffer.Full":


### PR DESCRIPTION
...paused too early before it's compete. For some reason it still does not go to the last frame - flowplayer flash behaves the same. I suspect that this is a bug in the RTMP server.
