### PR TITLE
Always remove sources and set src of video tag in first-frame setups

### DIFF
--- a/lib/engine/html5.js
+++ b/lib/engine/html5.js
@@ -112,6 +112,11 @@ flowplayer.engine.html5 = function(player, root) {
          } else {
 
             api = videoTag[0];
+            var sources = videoTag.find('source');
+            if (!api.src && sources.length) {
+               api.src = video.src;
+               sources.remove();
+            }
 
             // change of clip
             if (player.video.src && video.src != player.video.src) {


### PR DESCRIPTION
Internet Explorer (9) always prefers source tags before src-attribute
it also prevents touching the sources tags while playing the video so
the sources have to be removed before playback to get playlist item
switching working.

Fixes #345
