### PR TITLE
If no index passed to play API method - resume and return

### DIFF
--- a/lib/ext/playlist.js
+++ b/lib/ext/playlist.js
@@ -15,7 +15,10 @@ flowplayer(function(player, root) {
 
 
    player.play = function(i) {
-      if (i === undefined) player.resume();
+      if (i === undefined){
+          player.resume();
+          return player;
+      }
       if (typeof i === 'number' && !player.conf.playlist[i]) return player;
       else if (typeof i != 'number') player.load.apply(null, arguments);
       player.unbind('resume.fromfirst'); // Don't start from beginning if clip explicitely chosen


### PR DESCRIPTION
Hi!

This pull request fixes the "TypeError: Cannot call method 'map' of undefined" error, which happens when you call flowplayer().play() API method (on any demo page). I've just added the return statement after player.resume() call.

How to reproduce this error:

Go to http://flowplayer.org/standalone/playlist/grid.html and open the console in dev tools.
Call flowplayer().play() and see the error:

![screen shot 2013-04-30 at 11 37 15 am](https://f.cloud.github.com/assets/576700/443312/b286c3b6-b17a-11e2-910c-87ea05974778.png)
