### PR TITLE
Set preload attribute for newly created video tag on it's own line

### DIFF
--- a/lib/flowplayer.js
+++ b/lib/flowplayer.js
@@ -125,7 +125,8 @@ $.fn.flowplayer = function(opts, callback) {
       if (conf.playlist.length) { // Create initial video tag if called without
          var preload = videoTag.attr('preload');
          videoTag.remove();
-         videoTag = $('<video />').addClass('fp-engine').appendTo(root).attr('preload', preload);
+         videoTag = $('<video />').addClass('fp-engine').appendTo(root);
+         videoTag.attr('preload', preload);
          if (typeof conf.playlist[0] === 'string') videoTag.attr('src', conf.playlist[0]);
          else {
             $.each(conf.playlist[0], function(i, plObj) {


### PR DESCRIPTION
Because older jQuery seems to return undefined instead of an empty
string,  we won't have the actual element reference in our variable

Fixes #369
