### PR TITLE
Match user agent directly instead of $.browser variable

### DIFF
--- a/lib/ext/fullscreen.js
+++ b/lib/ext/fullscreen.js
@@ -4,13 +4,14 @@ var VENDOR = $.browser.mozilla ? "moz": "webkit",
    FS_EXIT = "fullscreen-exit",
    FULL_PLAYER,
    FS_SUPPORT = flowplayer.support.fullscreen,
-   FS_NATIVE_SUPPORT = typeof document.exitFullscreen == 'function';
+   FS_NATIVE_SUPPORT = typeof document.exitFullscreen == 'function',
+   ua = navigator.userAgent.toLowerCase(),
+   IS_SAFARI = /(safari)[ \/]([\w.]+)/.exec(ua) && !/(chrome)[ \/]([\w.]+)/.exec(ua);
 
 
 // esc button
 $(document).bind(FS_NATIVE_SUPPORT ? "fullscreenchange" : VENDOR + "fullscreenchange", function(e) {
    var el = $(document.webkitCurrentFullScreenElement || document.mozFullScreenElement || document.fullscreenElement || e.target);
-
    if (el.length && !FULL_PLAYER) {
       FULL_PLAYER = el.trigger(FS_ENTER, [el]);
    } else {
@@ -46,7 +47,7 @@ flowplayer(function(player, root) {
                root[0].requestFullscreen();
             } else {
                root[0][VENDOR + 'RequestFullScreen'](Element.ALLOW_KEYBOARD_INPUT);
-               if ($.browser.safari && !document.webkitCurrentFullScreenElement && !document.mozFullScreenElement) { // Element.ALLOW_KEYBOARD_INPUT not allowed
+               if (IS_SAFARI && !document.webkitCurrentFullScreenElement && !document.mozFullScreenElement) { // Element.ALLOW_KEYBOARD_INPUT not allowed
                   root[0][VENDOR + 'RequestFullScreen']();
                }
             }


### PR DESCRIPTION
Our version of $.browser works differently than the "native"
version in jQuery 1.7

Fixes #369
