### PR TITLE
Handle playlist element and video element insertion consistently

### DIFF
--- a/lib/ext/playlist.js
+++ b/lib/ext/playlist.js
@@ -22,7 +22,7 @@ flowplayer(function(player, root) {
       player.video.index = i;
       player.load(typeof player.conf.playlist[i] === 'string' ?
          player.conf.playlist[i].toString() :
-         player.conf.playlist[i].map(function(item) { return $.extend({}, item); })
+         $.map(player.conf.playlist[i], function(item) { return $.extend({}, item); })
       );
       return player;
    };
@@ -80,7 +80,8 @@ flowplayer(function(player, root) {
       var plEl = root.find('.fp-playlist');
       if (!plEl.length) {
          plEl = $('<div class="fp-playlist"></div>');
-         $('video', root).after(plEl);
+         var cntrls = $('.fp-next,.fp-prev', root).eq(0).before(plEl);
+         if (!cntrls.length) $('video', root).after(plEl);
       }
       plEl.empty();
       $.each(player.conf.playlist, function(i, item) {

--- a/lib/flowplayer.js
+++ b/lib/flowplayer.js
@@ -124,9 +124,10 @@ $.fn.flowplayer = function(opts, callback) {
          engine;
 
       if (conf.playlist.length) { // Create initial video tag if called without
-         var preload = videoTag.attr('preload');
-         videoTag.remove();
-         videoTag = $('<video />').addClass('fp-engine').appendTo(root);
+         var preload = videoTag.attr('preload'), placeHolder;
+         if (videoTag.length) videoTag.replaceWith(placeHolder = $('<p />'));
+         videoTag = $('<video />').addClass('fp-engine');
+         placeHolder ? placeHolder.replaceWith(videoTag) : root.prepend(videoTag);
          videoTag.attr('preload', preload);
          if (typeof conf.playlist[0] === 'string') videoTag.attr('src', conf.playlist[0]);
          else {


### PR DESCRIPTION
This fixes #427 - issue with non-clickable prev and next elements
Also use jQuery map-polyfill for older browsers, fixes #426
