### PR TITLE
CONTRIBUTING: fix links, advice to search forum first (#437)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,17 +1,18 @@
 ## Reporting issues
 
-Before you [report an issue](/flowplayer/flowplayer/issues/) please make sure to
+Before you [report an issue](https://github.com/flowplayer/flowplayer/issues/) please make sure to
 
-1. search for the issue if it's already posted
-2. include a live example. please use as minimal HTML/CSS/JS as possible (or use http://jsfiddle.net/)
-3. tell us which browser, browser version and operating system you are using
+1. make sure it is not a usage issue by searching our [forum](http://flowplayer.org/forum/)
+2. search the bug tracker for the issue if it's already posted
+3. include a live example. please use as minimal HTML/CSS/JS as possible (or use http://jsfiddle.net/)
+4. tell us which browser, browser version and operating system you are using
 
 ## Committing code
 
 We prefer
 
 - [Pull Requests](http://help.github.com/send-pull-requests/) with a clear title and description.
-- Bug fixes and features that originate from an [issue](/flowplayer/flowplayer/issues/)
+- Bug fixes and features that originate from an [issue](https://github.com/flowplayer/flowplayer/issues/)
 - Commits that are [tagged](https://github.com/blog/831-issues-2-0-the-next-generation) with issues
 - Smaller commits rather than large ones
 


### PR DESCRIPTION
Bug tracker cannot be linked absolutely or relatively from repo.
