### PR TITLE
Prevent key code 219 from triggering help (#466)

### DIFF
--- a/lib/ext/keyboard.js
+++ b/lib/ext/keyboard.js
@@ -14,7 +14,7 @@ $(document).bind("keydown.fp", function(e) {
    if (!el || !conf.keyboard || el.disabled) return;
 
    // help dialog (shift key not truly required)
-   if ($.inArray(key, [63, 187, 191, 219]) != -1) {
+   if ($.inArray(key, [63, 187, 191]) != -1) {
       focusedRoot.toggleClass(IS_HELP);
       return false;
    }


### PR DESCRIPTION
The opening bracket/brace is bound to "back" in most browsers.
Having the help appear is a constant surprise for keyboard freaks.
