### PR TITLE
fullscreen: resume current position in webkit over rtmp (#389)

### DIFF
--- a/lib/ext/fullscreen.js
+++ b/lib/ext/fullscreen.js
@@ -40,6 +40,10 @@ flowplayer(function(player, root) {
 
       if (flag) scrollTop = win.scrollTop();
 
+      if ((VENDOR == "webkit" || IS_SAFARI) && player.engine == "flash" && player.conf.rtmp)
+	     // avoid restart on fullscreen toggle
+         fsSeek = {pos: player.video.time, play: player.playing};
+
       if (FS_SUPPORT) {
 
          if (flag) {
@@ -61,9 +65,7 @@ flowplayer(function(player, root) {
          }
 
       } else {
-         if (player.engine === "flash" && player.conf.rtmp)
-            fsSeek = {pos: player.video.time, play: player.playing};
-         player.trigger(flag ? FS_ENTER : FS_EXIT, [player])
+         player.trigger(flag ? FS_ENTER : FS_EXIT, [player]);
       }
 
       return player;
@@ -87,16 +89,11 @@ flowplayer(function(player, root) {
 
    }).bind("ready", function () {
       if (fsSeek.pos && !isNaN(fsSeek.pos)) {
-         setTimeout(function () {
-            player.play(); // avoid hang in buffering state
-            player.seek(fsSeek.pos);
-            if (!fsSeek.play) {
-               setTimeout(function () {
-                  player.pause();
-               }, 100);
-            }
+         player.play().seek(fsSeek.pos, function () {
+            if (!fsSeek.play)
+               player.pause();
             fsSeek = {pos: 0, play: false};
-         }, 250);
+         });
       }
    });
 


### PR DESCRIPTION
- erroneously the problem of restarting was assumed to be connected to
  "windowed" fullscreen when in fact it concerned webkit browsers and windows
  Safari
- clean out the timeout by using the seek callback

Note: this does not solve the problem in conjunction with playlists, the first clip is resumed always!
