### PR TITLE
Work around flash fs toggle issues in webkit (#126, #389)

### DIFF
--- a/lib/ext/fullscreen.js
+++ b/lib/ext/fullscreen.js
@@ -96,14 +96,12 @@ flowplayer(function(player, root) {
           player.play(fsResume.index);
           // above loads "different" clip, resume position below
           fsResume.index = 0;
-      } else {
-         if (fsResume.pos && !isNaN(fsResume.pos)) {
-            player.resume().seek(fsResume.pos, function () {
-               if (!fsResume.play)
-                  player.pause();
-               $.extend(fsResume, {pos: 0, play: false});
-            });
-         }
+      } else if (fsResume.pos && !isNaN(fsResume.pos)) {
+         player.resume().seek(fsResume.pos, function () {
+            if (!fsResume.play)
+               player.pause();
+            $.extend(fsResume, {pos: 0, play: false});
+         });
       }
    });
 


### PR DESCRIPTION
- detect troublesome browsers correctly (webkit, windows Safari)
- always resume current clip in playlist
- over rtmp seek to current position

The latter cannot be approximated reliably with progressive download
because of issue #472 - although the video is buffered to the current
position there are problems with seeking on start.
