### PR TITLE
Webkit rounding issue was causing buffered event to not fire

### DIFF
--- a/lib/engine/html5.js
+++ b/lib/engine/html5.js
@@ -245,7 +245,7 @@ flowplayer.engine.html5 = function(player, root) {
                      } catch (ignored) {}
 
                      if (arg.buffer) {
-                        if (round(arg.buffer, 1000) < arg.duration && !arg.buffered) {
+                        if (round(arg.buffer, 1000) < round(arg.duration, 1000) && !arg.buffered) {
                            player.trigger("buffer", e);
 
                         } else if (!arg.buffered) {


### PR DESCRIPTION
Webkit was rounding the duration value, which was causing the buffered attribute to never look complete.  This was causing the buffered event to never fire.  To fix this I added support to the round function to specify a precision, then used that to normalize the values.
