### PR TITLE
Unbind esc (#469)

### DIFF
--- a/lib/ext/keyboard.js
+++ b/lib/ext/keyboard.js
@@ -48,7 +48,7 @@ $(document).bind("keydown.fp", function(e) {
          case 32: el.toggle(); break;                                      // spacebar
          case 70: conf.fullscreen && el.fullscreen(); break;               // toggle fullscreen
          case 77: el.mute(); break;                                        // mute
-         case 27: el[el.isFullscreen ? "fullscreen" : "unload"](); break;  // esc
+         case 81: el[el.isFullscreen ? "stop" : "unload"](); break;        // stop/unload
       }
 
    }
@@ -72,7 +72,7 @@ flowplayer(function(api, root) {
          <a class="fp-close"></a>\
          <div class="fp-help-section fp-help-basics">\
             <p><em>space</em>play / pause</p>\
-            <p><em>esc</em>stop</p>\
+            <p><em>q</em>stop</p>\
             <p><em>f</em>fullscreen</p>\
             <p><em>shift</em> + <em>&#8592;</em><em>&#8594;</em>slower / faster <small>(latest Chrome and Safari)</small></p>\
          </div>\


### PR DESCRIPTION
- esc is a prominent browser binding, do not bind it at all, especially
  not to any action involving fullscreen
- bind q to stop - or unload when not in fullscreen, but in a splash
  setup
