### PR TITLE
Flash Buffered Event Firing Multiple Times

### DIFF
--- a/lib/engine/flash.js
+++ b/lib/engine/flash.js
@@ -103,23 +103,26 @@ flowplayer.engine.flash = function(player, root) {
                   case "click": event.flash = true; break;
                   case "keydown": event.which = arg; break;
                   case "seek": video.time = arg; break;
-                  case "buffered": video.buffered = true; break;
 
                   case "status":
                      player.trigger("progress", arg.time);
 
-                     if (arg.buffer <= video.bytes && !video.buffered) {
+                     if (arg.buffer < video.bytes && !video.buffered) {
                         video.buffer = arg.buffer / video.bytes * video.duration;
                         player.trigger("buffer", video.buffer);
-
-                     } else if (video.buffered) player.trigger("buffered");
+                     } else if (!video.buffered) {
+                        video.buffered = true;
+                        player.trigger("buffered");
+                     }
 
                      break;
 
                }
 
-               // add some delay to that player is truly ready after an event
-               setTimeout(function() { player.trigger(event, arg); }, 1)
+               if (type != 'buffered') {
+                  // add some delay so that player is truly ready after an event
+                  setTimeout(function() { player.trigger(event, arg); }, 1)
+               }
 
             };
 


### PR DESCRIPTION
The `buffered` event was being fired every time more buffer was loaded.  This PR fixes that and now correctly fires the 'buffer' event when new buffer is loaded, and the `buffered` event only once buffer completes.
