### PR TITLE
fix js errors when jquery throttle plugin is already used

### DIFF
--- a/lib/ext/slider.js
+++ b/lib/ext/slider.js
@@ -5,18 +5,20 @@
 
 
 // execute function every <delay> ms
-$.throttle = function(fn, delay) {
-   var locked;
-
-   return function () {
-      if (!locked) {
-         fn.apply(this, arguments);
-         locked = 1;
-         setTimeout(function () { locked = 0; }, delay);
-      }
+if (!$.throttle)
+{
+   $.throttle = function(fn, delay) {
+      var locked;
+   
+      return function () {
+         if (!locked) {
+            fn.apply(this, arguments);
+            locked = 1;
+            setTimeout(function () { locked = 0; }, delay);
+         }
+      };
    };
-};
-
+}
 
 $.fn.slider2 = function(rtl) {
 


### PR DESCRIPTION
If we want to make sure we're using our own throttle implementation, let's give it a more custom name or don't add it to jquery and use better namespacing.
