### PR TITLE
Resume live stream after flash webkit fullscreen toggle (#569)

### DIFF
--- a/lib/ext/fullscreen.js
+++ b/lib/ext/fullscreen.js
@@ -97,11 +97,18 @@ flowplayer(function(player, root) {
           // above loads "different" clip, resume position below
           fsResume.index = 0;
       } else if (fsResume.pos && !isNaN(fsResume.pos)) {
-         player.resume().seek(fsResume.pos, function () {
+         var fsreset = function () {
             if (!fsResume.play)
                player.pause();
             $.extend(fsResume, {pos: 0, play: false});
-         });
+         };
+
+         if (player.conf.live) {
+            player.resume();
+            fsreset();
+         } else {
+            player.resume().seek(fsResume.pos, fsreset);
+         }
       }
    });
 


### PR DESCRIPTION
Caveat: This is not a true resume.
The JavaScript working around the Flash reset on fullscreen toggle will
cause live streams to "resume" at 0 in WebKit browsers.
