### PR TITLE
Configurable hiding timeout for controlbar

### DIFF
--- a/lib/ext/ui.js
+++ b/lib/ext/ui.js
@@ -220,7 +220,7 @@ flowplayer(function(api, root) {
          });
 
          hovertimer = setInterval(function() {
-            if (new Date - lastMove > 5000) {
+            if (new Date - lastMove > conf.controlbarTimeout) {
                hover(false)
                lastMove = new Date;
             }

--- a/lib/flowplayer.js
+++ b/lib/flowplayer.js
@@ -75,6 +75,8 @@ $.extend(flowplayer, {
 
       tooltip: true,
 
+			controlbarTimeout: 5000,
+
       // initial volume level
       volume: typeof localStorage != "object" ? 1 : localStorage.muted == "true" ? 0 : !isNaN(localStorage.volume) ? localStorage.volume || 1 : 1,
 


### PR DESCRIPTION
In fullscreen, when you have no possibilities to move cursor out of video is 5 second too long for controlbal to disappear. This add options for hiding controlbar timeout configurable with 5 seconds as default.
