### PR TITLE
Add preload parameter to video tags if specified in conf

### DIFF
--- a/lib/flowplayer.js
+++ b/lib/flowplayer.js
@@ -134,7 +134,7 @@ $.fn.flowplayer = function(opts, callback) {
          engine;
 
       if (conf.playlist.length) { // Create initial video tag if called without
-         var preload = videoTag.attr('preload'), placeHolder;
+         var preload = conf.preload || videoTag.attr('preload'), placeHolder;
          if (videoTag.length) videoTag.replaceWith(placeHolder = $('<p />'));
          videoTag = $('<video />').addClass('fp-engine');
          placeHolder ? placeHolder.replaceWith(videoTag) : root.prepend(videoTag);


### PR DESCRIPTION
I use the following to initialise Flowplayer from JavaScript:

$(element).flowplayer({
  preload: 'none',
  swf: '/static/flowplayer-5.4.6/flowplayer.swf',
  poster: '/path/to/screenshot',
  playlist: [
    [ { mp4: '/path/to/mp4' } ]
  ]
});

For some reason the player stopped working totally. I found out this is because the code expected the preload parameter to be none, but the actual parameter was never added to the generated video tag.

I found the right place in the code and patched it to use the given preload value instead of videoTag value if specified. This seems quite intuitive to me, since if preload is specified in JavaScript it makes sense to assume it will override any possible DOM values.
