### PR TITLE
Update html5.js

### DIFF
--- a/lib/engine/html5.js
+++ b/lib/engine/html5.js
@@ -1,4 +1,3 @@
-
 var VIDEO = $('<video/>')[0];
 
 // HTML5 --> Flowplayer event
@@ -75,7 +74,8 @@ flowplayer.engine.html5 = function(player, root) {
       conf = player.conf,
       self,
       timer,
-      api;
+      api,
+	   videoOvertaken = false;;
 
    return self = {
 
@@ -92,7 +92,11 @@ flowplayer.engine.html5 = function(player, root) {
       },
 
       load: function(video) {
-
+         
+         if (videoOvertaken) {
+   			videoOvertaken = false;
+   			listen(api, $("source", videoTag).add(videoTag), video);
+   		}
          if (conf.splash && !api) {
 
             videoTag = createVideoTag(video).prependTo(root);
@@ -109,7 +113,25 @@ flowplayer.engine.html5 = function(player, root) {
             if (conf.loop) videoTag.attr("loop", "loop");
 
             api = videoTag[0];
-
+            
+            if (navigator.userAgent.indexOf('iPad') > -1 || navigator.userAgent.indexOf('Android') > -1) {
+   				if (player.allowVideoOvertake == true) {
+   
+   					root.trigger("overtakeVideo");
+   					
+   	//				videoTag = createVideoTag(video).prependTo(root);
+   					videoTag[0].load();
+   					videoTag[0].play();
+   					videoTag[0].pause();
+   					
+   					player.allowVideoOvertake = false;
+   					videoOvertaken = true;
+   					//root.removeClass("is-loading");
+   					player.loading = false;
+   					return;
+   				}
+   			}
+			
          } else {
 
             api = videoTag[0];


### PR DESCRIPTION
These changes enable ads with video content running over the flowplayer player on Android and iOS devices. The logic behind this code is this:
- on init, if the plugin needs to display some video content (for example an ad), it sets the allowVideoOvertake variable to true.
flowplayer(function(api, root) {
    api.allowVideoOvertake = true;
    ....
}

- The plugin must then listen for the overtakeVideo event to be fired, and the video(s) from the plugin must be loaded and initialized at this point.