### PR TITLE
Skin: Extend CSS3 gradient support

### DIFF
--- a/skin/styl/core/css3.styl
+++ b/skin/styl/core/css3.styl
@@ -30,15 +30,18 @@ animation()
 animation-delay()
   vendor('animation-delay', arguments)
 
-gradient(from = #f9, to = #d, args...)
-   background-image -moz-linear-gradient(from, to) args
-   background-image -webkit-gradient(linear, 0 0, 0 100%, from(from), to(to)) args
+gradient(start = #f9, end = #d, args...)
+  background-image -webkit-gradient(linear, left top, left bottom, from(start), to(end)) args
+  background-image -webkit-linear-gradient(top, start, end) args
+  background-image -moz-linear-gradient(top, start, end) args
+  background-image -o-linear-gradient(top, start, end) args
+  background-image linear-gradient(to bottom, start, end) args
 
-radial-gradient(from = rgba(#0, 0.5), to = rgba(#0, 0.8))
-   background-color to
-   background -webkit-radial-gradient(50% 50%, ellipse closest-corner, from 1%, to 100%)
-   background -moz-radial-gradient(50% 50%, ellipse closest-corner, from 1%, to 100%)
-   background -ms-radial-gradient(50% 50%, ellipse closest-corner, from 1%, to 100%)
+radial-gradient(start = rgba(#0, 0.5), end = rgba(#0, 0.8))
+  background-color end
+  background -webkit-radial-gradient(50% 50%, ellipse closest-corner, start 1%, end 100%)
+  background -moz-radial-gradient(50% 50%, ellipse closest-corner, start 1%, end 100%)
+  background -ms-radial-gradient(50% 50%, ellipse closest-corner, start 1%, end 100%)
 
 opacity(n)
    opacity: n


### PR DESCRIPTION
Add CSS3 gradient support for the following browsers:
- Chrome, Safari 4+
- Chrome 10-25, iOS 5+, Safari 5.1+
- Firefox 3.6-15
- Opera 11.10-12.00
- Chrome 26, Firefox 16+, IE 10+, Opera 12.10+

Renamed parameters 'from' and 'to' to 'start' and 'end' so they don't get mixed up with the
property 'to bottom' introduced in the prefix-free linear-gradient.
