### PR TITLE
- danielr - fixes for local storage support checks. In IOS private brows...

### DIFF
--- a/lib/flowplayer.js
+++ b/lib/flowplayer.js
@@ -36,7 +36,9 @@ try {
     window.localStorage.flowplayerTestStorage = "test";
     supportLocalStorage = true;
   }
-} catch (ignored) {}
+} catch (ignored) {
+    supportLocalStorage = false;
+}
 
 $.extend(flowplayer, {
 
@@ -159,8 +161,9 @@ $.fn.flowplayer = function(opts, callback) {
 
       root.data('fp-player_id', root.data('fp-player_id') || playerCount++);
 
+      //danielr - check for local storage support. In IOS private browsing this is still available but will throw exceptions.
       try {
-         storage = window.localStorage || storage;
+          storage = supportLocalStorage ? window.localStorage : storage;
       } catch(e) {}
 
       var isRTL = (this.currentStyle && this.currentStyle['direction'] === 'rtl')
@@ -282,8 +285,11 @@ $.fn.flowplayer = function(opts, callback) {
 
          mute: function(flag) {
             if (flag === undefined) flag = !api.muted;
+
             storage.muted = api.muted = flag;
             storage.volume = !isNaN(storage.volume) ? storage.volume : conf.volume; // make sure storage has volume
+
+
             api.volume(flag ? 0 : storage.volume, true);
             api.trigger("mute", flag);
             return api;


### PR DESCRIPTION
There is a bug in IOS where the local storage is still available in private browsing mode yet will throw unhandled exceptions and break the player. Have a look thanks. 
