### PR TITLE
- danielr - use on instead of click to capture dynamically added navigation.

### DIFF
--- a/lib/ext/playlist.js
+++ b/lib/ext/playlist.js
@@ -47,8 +47,10 @@ flowplayer(function(player, root) {
       return player;
    };
 
-   $('.fp-next', root).click(player.next);
-   $('.fp-prev', root).click(player.prev);
+   //danielr - use on instead of click to capture dynamically added navigation. Requires jquery 1.7 though.
+   root.on("click", ".fp-next", player.next);
+   root.on("click", ".fp-prev", player.next);
+
 
    if (conf.advance) {
       root.unbind("finish.pl").bind("finish.pl", function(e, player) {


### PR DESCRIPTION
There may be a use case where people would like playlist navigation on the controlbar like so

 $(".fp-controls", root).children().eq(0).after(
                $("<div/>").addClass("fp-prev"),
                $("<div/>").addClass("fp-next")
        );

If this happens after the playlist plugin is added it will not capture the clicks unless on is used. I am providing a feature for this because there is no such thing and I suppose others would need this too. I have something similar for the markers plugin but its for seeking to marker cuepoints. 

I will have to duplicate the code for now. 

Please review thanks. 
