### PR TITLE
Force preload="none" for rtmp live (#509)

### DIFF
--- a/lib/engine/flash.js
+++ b/lib/engine/flash.js
@@ -75,15 +75,17 @@ flowplayer.engine.flash = function(player, root) {
             if (is_absolute) delete conf.rtmp;
 
             // optional conf
-            $.each(['key', 'autoplay', 'preload', 'rtmp', 'loop', 'debug', 'preload', 'splash'], function(i, key) {
+            $.each(['key', 'autoplay', 'preload', 'rtmp', 'live', 'loop', 'debug', 'splash'], function(i, key) {
                if (conf[key]) opts[key] = conf[key];
             });
             // bufferTime might be 0
             if (conf.bufferTime !== undefined) opts.bufferTime = conf.bufferTime;
 
-            // issue #376
+            // issues #376, #509
             if (opts.rtmp) {
                opts.rtmp = escapeURL(opts.rtmp);
+
+               if (opts.live) opts.preload = "none";
             }
 
             objectTag = embed(conf.swf, opts);


### PR DESCRIPTION
- add `live' to flash opts
- remove duplicate `preload' from flash opts
- force preload="none" if live and rtmp

TODO: throw error if live is configured without rtmp?
