### PR TITLE
Fine tune controls hover animation (#526)

### DIFF
--- a/skin/styl/core/state.styl
+++ b/skin/styl/core/state.styl
@@ -83,6 +83,19 @@
          opacity 0
          transition opacity fade_speed fade_delay
 
+      // mouseout fullscreen
+      &.is-fullscreen
+         .fp-controls
+            transition bottom fade_speed fade_delay
+
+         .fp-play, .fp-time, .fp-volume
+            opacity 0
+            transition opacity fade_speed 0
+
+         // reinstate opacity transition for aside-time
+         .aside-time&
+            .fp-time
+               transition opacity fade_speed fade_delay
 
    // mouseover / fixed-controls
    &.is-mouseover, &.fixed-controls


### PR DESCRIPTION
As in fullscreen the slim mouseout timeline is not below the container -
bottom: 0 - but bottom: 3px there is a vertical jump of the timeline in
the mouseover to mouseout transition: During the hide delay of .3 secs
the still visible timeline as part of the controlbar is 'pushed up'.

To prevent this:
- bottom transition for fp-controls in fullscreen mouseout state
- opacity transition to 0 for fp-play fp-time fp-volume in fullscreen
  mouseout state - with a delay of 0 so the widgets are not visible when
  timeline already has disappeared
- reinstate the opacity transition with the default hide delay for
  fp-time of aside-time players
