### PR TITLE
subtitle: fix end regex group retrieval (#677)

### DIFF
--- a/lib/ext/subtitle.js
+++ b/lib/ext/subtitle.js
@@ -15,7 +15,7 @@ flowplayer(function(player, root, engine) {
    // avoid duplicate loads
    track.remove();
 
-   var TIMECODE_RE = /^(([0-9]{2}:)?[0-9]{2}:[0-9]{2}[,.]{1}[0-9]{3}) --\> (([0-9]{2}:)?[0-9]{2}:[0-9]{2}[,.]{1}[0-9]{3})(.*)/;
+   var TIMECODE_RE = /^(([0-9]{2}:){1,2}[0-9]{2}[,.][0-9]{3}) --\> (([0-9]{2}:){1,2}[0-9]{2}[,.][0-9]{3})(.*)/;
 
    function seconds(timecode) {
       var els = timecode.split(':');
@@ -48,7 +48,7 @@ flowplayer(function(player, root, engine) {
                entry = {
                   title: title,
                   startTime: seconds(timecode[1]),
-                  endTime: seconds(timecode[2] || timecode[3]),
+                  endTime: seconds(timecode[3]),
                   text: text
                };
 


### PR DESCRIPTION
Nested regex groups are counted from left to right:
(group1 (group2)) (group3)
Therefore the end group boolean should have checked group 3 before 2 and
not the other way round.
Change the TIMECODE_RE in such a way the the start group _always_
contains a nested group. This not only makes the regex more compact, but
it is also safer as we never accidentally retrieve (.*) at eol:

/^(([0-9]{2}:){1,2}[0-9]{2}[,.][0-9]{3}) --> (([0-9]{2}:){1,2}[0-9]{2}[,.][0-9]{3})(.*)/;
  -( group2  ).....-----group1----------      -( group4  ).....-----group3----------
