### PR TITLE
Fix #288 - Delay video tag event listening

### DIFF
--- a/lib/engine/html5.js
+++ b/lib/engine/html5.js
@@ -145,7 +145,7 @@ flowplayer.engine.html5 = function(player, root) {
 
          }
 
-         listen(api, $("source", videoTag).add(videoTag), video);
+         setTimeout(function() { listen(api, $("source", videoTag).add(videoTag), video); });
 
          // iPad (+others?) demands load()
          if (conf.preload != 'none' && video.type != "mpegurl" || !support.zeropreload || !support.dataload) api.load();


### PR DESCRIPTION
If we attach video handlers on same eventloop tick that we modify the
video tag, in first frame setups the video tag might in some cases emit
error events we are not interested in.

Now we let the load-method finish and the browser do it's things before
attaching video tag handlers.

This needs thorough testing with different setups and devices so that we
don't accidentally break anything.
