### PR TITLE
WebKit fsResume condition must be based on video src (#740)

### DIFF
--- a/lib/ext/fullscreen.js
+++ b/lib/ext/fullscreen.js
@@ -95,7 +95,7 @@ flowplayer(function(player, root) {
       player.isFullscreen = false;
       win.scrollTop(scrollTop);
 
-   }).bind("ready", function () {
+   }).bind("ready", function (e, api, video) {
       if (fsResume.apply) {
          var fsreset = function () {
             if (!fsResume.play && !player.conf.live) {
@@ -108,7 +108,7 @@ flowplayer(function(player, root) {
 
          if (player.conf.live) {
             fsreset();
-         } else if (player.conf.rtmp && fsResume.pos && !isNaN(fsResume.pos)) {
+         } else if (/^rtmp[st]?:\/\//.test(video.url) && fsResume.pos && !isNaN(fsResume.pos)) {
             player.resume();
             player.seek(fsResume.pos, fsreset);
          } else {


### PR DESCRIPTION
After 5.5.1 we cannot rely on conf.rtmp anymore, but we now can rely on
the full rtmp url being present as video.url on ready.

video.src is currently also the full rtmp url, but may not reliable in
the long term.
