### PR TITLE
Flash callback redux

### DIFF
--- a/lib/engine/flash.js
+++ b/lib/engine/flash.js
@@ -18,23 +18,6 @@ engineImpl = function flashEngine(player, root) {
 
    var win = window;
 
-   var readyCallback = function () {
-      // write out video url to handle fullscreen toggle and api load
-      // in WebKit and Safari
-      if (common.webkit) {
-         var flashvars = Sizzle('object param[name="flashvars"]', root)[0],
-            flashprops = (common.attr(flashvars, 'value') || '').split("&");
-
-         flashprops.forEach(function(prop, i) {
-			      prop = prop.split("=");
-            if (prop[0] == "url" && prop[1] != player.video.url) {
-			         flashprops[i] = "url=" + player.video.url;
-			         common.attr(flashvars, 'value', flashprops.join("&"));
-            }
-         });
-      }
-
-   };
    var fullscreenCallback = function(e) {
       // handle Flash object aspect ratio - not needed for hls
       var origH = common.height(root),
@@ -137,8 +120,7 @@ engineImpl = function flashEngine(player, root) {
 
          } else {
 
-            player.on('ready.flashengine', readyCallback)
-                  .on("ready.flashengine fullscreen.flashengine fullscreen-exit.flashengine", fullscreenCallback);
+            player.on("ready.flashengine fullscreen.flashengine fullscreen-exit.flashengine", fullscreenCallback);
 
             callbackId = "fpCallback" + ("" + Math.random()).slice(3, 15);
 

--- a/lib/engine/flash.js
+++ b/lib/engine/flash.js
@@ -20,7 +20,7 @@ engineImpl = function flashEngine(player, root) {
 
    var readyCallback = function () {
       // write out video url to handle fullscreen toggle and api load
-      // in WebKit and Safari - see also fsResume
+      // in WebKit and Safari
       if (common.webkit) {
          var flashvars = Sizzle('object param[name="flashvars"]', root)[0],
             flashprops = (common.attr(flashvars, 'value') || '').split("&");
@@ -36,11 +36,11 @@ engineImpl = function flashEngine(player, root) {
 
    };
    var fullscreenCallback = function(e) {
-      // handle Flash object aspect ratio
+      // handle Flash object aspect ratio - not needed for hls
       var origH = common.height(root),
          origW = common.width(root);
 
-      if (player.conf.flashfit || /full/.test(e.type)) {
+      if (!/mpegurl/i.test(player.video.type) && (player.conf.flashfit || /full/.test(e.type))) {
 
          var fs = player.isFullscreen,
             truefs = fs && flowplayer.support.fullscreen,


### PR DESCRIPTION
- flash hls itself handles video and therefore object resizing
- webkit ready callback obsolete because there's no flash re-init anymore