### PR TITLE
Remove crossorigin attribute from videotag

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -109,7 +109,11 @@ common.attr = function(el, key, val) {
       }
     }
   } else {
-    el.setAttribute(key, val);
+    if (val === false) {
+      el.removeAttribute(key);
+    } else {
+      el.setAttribute(key, val);
+    }
   }
   return el;
 };

--- a/lib/engine/html5.js
+++ b/lib/engine/html5.js
@@ -120,6 +120,7 @@ engine = function(player, root) {
          } else {
            ClassList(api).add('fp-engine');
            common.find('source,track', api).forEach(common.removeNode);
+           if (!player.conf.nativesubtitles) common.attr(api, 'crossorigin', false);
            reload = api.src === video.src;
          }
          if (!support.inlineVideo) {


### PR DESCRIPTION
If crossorigin attribute set and no cross-domain subtitle tracks loaded
the player vill error at least on chrome

Fixes #826