### PR TITLE
Allow playlist items outside of the container

### DIFF
--- a/lib/ext/playlist.js
+++ b/lib/ext/playlist.js
@@ -6,7 +6,8 @@ var flowplayer = require('../flowplayer'),
     common = require('../common'),
     Resolve = require('./resolve'),
     resolver = new Resolve(),
-    $ = window.jQuery;
+    $ = window.jQuery,
+    externalRe = /^#/;
 flowplayer(function(player, root) {
 
    var conf = extend({ active: 'is-active', advance: true, query: ".fp-playlist a" }, player.conf),
@@ -14,6 +15,7 @@ flowplayer(function(player, root) {
 
    // getters
    function els() {
+     if (externalRe.test(conf.query)) return common.find(conf.query);
      return common.find(conf.query, root);
    }
 
@@ -161,7 +163,7 @@ flowplayer(function(player, root) {
     }
 
     /* click -> play */
-    bean.on(root, "click", conf.query, function(e) {
+    bean.on(externalRe.test(conf.query) ? document : root, "click", conf.query, function(e) {
        e.preventDefault();
        var el = e.currentTarget;
        var toPlay = Number(el.getAttribute('data-index'));


### PR DESCRIPTION
`conf.query` starting with the `#` sign will be treated as being outside
of the container

Fixes #443