### PR TITLE
Set a timeout delay for closing the second connection. Seems like it ca…

### DIFF
--- a/lib/as/ParallelConnector.as
+++ b/lib/as/ParallelConnector.as
@@ -76,8 +76,10 @@ public class ParallelConnector implements Connector {
                     debug("connection succeeded with " + connection.uri + ", already connected? " + connected);
 
                     if (connected || disconnected) {
-                        debug("Already " + (disconnected ? "disconnected" : "connected") + ", closing this 2nd connection");
-                        connection.close();
+                        setTimeout(function ():void {
+                            debug("Already " + (disconnected ? "disconnected" : "connected") + ", closing this 2nd connection");
+                            connection.close();
+                        }, 100);
                         return;
                     }
 


### PR DESCRIPTION
…nnot be closed properly in the "NetConnection.Connect.Success" event handler, at least not with Chrome & PepperFlash. If a RTMPT connection stays open, you can see RTMPT "x-fcx" network requests in the Chrome console. Fixes #748