### PR TITLE
flashls: make resume of live stream reliable

### DIFF
--- a/lib/as/HLSStreamProvider.as
+++ b/lib/as/HLSStreamProvider.as
@@ -99,7 +99,11 @@ package {
                     break;
                 case HLSPlayStates.PAUSED:
                 case HLSPlayStates.PAUSED_BUFFERING:
-                    hls.stream.resume();
+                    if (this.pos < 0) {
+                        hls.stream.play(null, -1);
+                    } else {
+                        hls.stream.resume();
+                    }
                     player.fire(Flowplayer.RESUME, null);
                     break;
                 // do nothing if already in play state


### PR DESCRIPTION
After a long wait, live streams could not be resumed.
Fix proposed by @mangui.