### PR TITLE
Detect live clip properly in ready handle (#898)

### DIFF
--- a/lib/engine/html5.js
+++ b/lib/engine/html5.js
@@ -249,7 +249,7 @@ engine = function(player, root) {
                   });
 
                   try {
-                     arg.seekable = !conf.live && /mpegurl/i.test(video ? (video.type || '') : '') && api.duration || api.seekable && api.seekable.end(null);
+                     arg.seekable = !player.live && /mpegurl/i.test(video ? (video.type || '') : '') && api.duration || api.seekable && api.seekable.end(null);
 
                   } catch (ignored) {}
 
@@ -275,7 +275,7 @@ engine = function(player, root) {
 
                   }, 250);
 
-                  if (!conf.live && !arg.duration && !support.hlsDuration && type === "loadeddata") {
+                  if (!player.live && !arg.duration && !support.hlsDuration && type === "loadeddata") {
                      var durationChanged = function() {
                         arg.duration = api.duration;
                         try {


### PR DESCRIPTION
Needed at least for Mac OS desktop Safari.
The greediness of the condition manifests itself because of
8dd719a64f03b09573eeed0a68876ae2b14d0bdd for Android.