### PR TITLE
Fix incorrect horizontal position of the context menu

### DIFF
--- a/lib/ext/ui.js
+++ b/lib/ext/ui.js
@@ -299,7 +299,7 @@ flowplayer(function(api, root) {
    bean.on(root, 'contextmenu', function(ev) {
       var o = common.offset(common.find('.fp-player', root)[0]),
           w = window,
-          left = ev.clientX - o.left,
+          left = ev.clientX - (o.left + w.scrollX),
           t = ev.clientY - (o.top + w.scrollY);
       var menu = common.find('.fp-context-menu', root)[0];
       if (!menu) return;


### PR DESCRIPTION
When there is a horizontal scrollbar in the browser and you scroll to the right, the context menu is not created next to the mouse cursor - it is placed to the right. It needs to take into account the horizontal scroll amount.