### PR TITLE
Fix for RTMP streams with no file format prefix. Shold fix #901

### DIFF
--- a/lib/flowplayer.js
+++ b/lib/flowplayer.js
@@ -277,7 +277,9 @@ function initializePlayer(element, opts, callback) {
             })));
 
             if (video.src) {
-               video.src = common.createElement('a', {href: video.src}).href;
+               video.src = common.createElement('a', {href: ( engine.engineName == 'flash' && video.src.match(/^\S+:/) ) ? video.src : 'fvrtmphotfix:'+video.src }).href;
+               video.src = video.src.replace(/^fvrtmphotfix:/,'');
+
                var e = api.trigger('load', [api, video, engine], true);
                if (!e.defaultPrevented) {
                   engine.load(video);


### PR DESCRIPTION
Should fix the issue discussed here: https://github.com/flowplayer/flowplayer/issues/901