### PR TITLE
Do not show loading animation when erroring out during seek

### DIFF
--- a/lib/ext/ui.js
+++ b/lib/ext/ui.js
@@ -217,6 +217,7 @@ flowplayer(function(api, root) {
 
    }).on("error", function(e, api, error) {
       common.removeClass(root, 'is-loading');
+      common.removeClass(root, 'is-seeking');
       common.addClass(root, 'is-error');
       if (error) {
          error.message = conf.errors[error.code];


### PR DESCRIPTION
is-seeking class has the same visual effect as is-loading, so remove it
as well.