### PR TITLE
Seek to generated cuepoint, not timeline position (#957)

### DIFF
--- a/lib/ext/cuepoint.js
+++ b/lib/ext/cuepoint.js
@@ -89,10 +89,8 @@ flowplayer(function(player, root) {
         timeline.appendChild(el);
         bean.on(el, 'mousedown', function(e) {
           e.preventDefault();
+          e.stopPropagation();
           player.seek(time);
-
-          // preventDefault() doesn't work
-          return false;
         });
     }
     return player;


### PR DESCRIPTION
The return false hack does not work in the version 6 layout, and is not
needed. The mousedown event just must prevented from propagating.