### PR TITLE
Make fp-title behave like other top aligned widgets on mouseout

### DIFF
--- a/skin/styl/core/state.styl
+++ b/skin/styl/core/state.styl
@@ -77,7 +77,7 @@
 
    // mouseout
    &.is-mouseout
-      .fp-controls, .fp-mute, .fp-title
+      .fp-controls, .fp-mute
          height 0
          transition height fade_speed fade_delay
        .fp-controls
@@ -96,7 +96,7 @@
          top 0
          border-radius 0
 
-      .fp-fullscreen, .fp-unload, .fp-elapsed, .fp-remaining, .fp-duration, .fp-embed, .fp-volume, .fp-play, .fp-menu, .fp-brand, .fp-timeline-tooltip, &.aside-time .fp-time
+      .fp-fullscreen, .fp-unload, .fp-elapsed, .fp-remaining, .fp-duration, .fp-embed, .fp-title, .fp-volume, .fp-play, .fp-menu, .fp-brand, .fp-timeline-tooltip, &.aside-time .fp-time
          opacity 0
          transition opacity fade_speed fade_delay
 


### PR DESCRIPTION
Fade to zero opacity instead of zero height.