### PR TITLE
Add a 'playlist_index' option to specify which playlist item to start on

### DIFF
--- a/lib/ext/playlist.js
+++ b/lib/ext/playlist.js
@@ -61,21 +61,20 @@ flowplayer(function(player, root) {
       return player;
    };
 
-   player.setPlaylist = function(items, playlist_index) {
+   player.setPlaylist = function(items) {
      player.conf.playlist = items;
-     player.conf.playlist_index = playlist_index;
      delete player.video.index;
      generatePlaylist();
      return player;
    };
 
    player.addPlaylistItem = function(item) {
-     return player.setPlaylist(player.conf.playlist.concat([item]), player.conf.playlist_index);
+     return player.setPlaylist(player.conf.playlist.concat([item]));
    };
 
    player.removePlaylistItem = function(idx) {
      var pl = player.conf.playlist;
-     return player.setPlaylist(pl.slice(0, idx).concat(pl.slice(idx+1)), player.conf.playlist_index);
+     return player.setPlaylist(pl.slice(0, idx).concat(pl.slice(idx+1)));
    };
 
    bean.on(root, 'click', '.fp-next', player.next);
@@ -99,7 +98,7 @@ flowplayer(function(player, root) {
 
             // If we have multiple items in playlist, start from the initial index (or the first)
             if (player.conf.playlist.length > 1) player.one("resume.fromfirst", function() {
-               player.play(player.conf.playlist_index || 0);
+               player.play(0);
                return false;
             });
          }
@@ -151,7 +150,7 @@ flowplayer(function(player, root) {
    if (player.conf.playlist.length) { // playlist configured by javascript, generate playlist
       playlistInitialized = true;
       generatePlaylist();
-      if (!player.conf.clip || !player.conf.clip.sources.length) player.conf.clip = player.conf.playlist[player.conf.playlist_index || 0];
+      if (!player.conf.clip || !player.conf.clip.sources.length) player.conf.clip = player.conf.playlist[player.conf.startIndex || 0];
    }
 
    if (els().length && !playlistInitialized) { //generate playlist from existing elements
@@ -182,7 +181,7 @@ flowplayer(function(player, root) {
        if (!player.conf.playlist.length) return;
        var prev = active()[0],
           prevIndex = prev && prev.getAttribute('data-index'),
-          index = video.index = (video.index !== undefined ? video.index : (player.video.index !== undefined ? player.video.index : player.conf.playlist_index || 0)),
+          index = video.index = (video.index !== undefined ? video.index : (player.video.index !== undefined ? player.video.index : player.conf.startIndex || 0)),
           el = common.find(conf.query +'[data-index="' + index + '"]', queryRoot())[0],
           is_last = index == player.conf.playlist.length - 1;
        if (prev) ClassList(prev).remove(klass);

--- a/lib/ext/playlist.js
+++ b/lib/ext/playlist.js
@@ -61,20 +61,21 @@ flowplayer(function(player, root) {
       return player;
    };
 
-   player.setPlaylist = function(items) {
+   player.setPlaylist = function(items, playlist_index) {
      player.conf.playlist = items;
+     player.conf.playlist_index = playlist_index;
      delete player.video.index;
      generatePlaylist();
      return player;
    };
 
    player.addPlaylistItem = function(item) {
-     return player.setPlaylist(player.conf.playlist.concat([item]));
+     return player.setPlaylist(player.conf.playlist.concat([item]), player.conf.playlist_index);
    };
 
    player.removePlaylistItem = function(idx) {
      var pl = player.conf.playlist;
-     return player.setPlaylist(pl.slice(0, idx).concat(pl.slice(idx+1)));
+     return player.setPlaylist(pl.slice(0, idx).concat(pl.slice(idx+1)), player.conf.playlist_index);
    };
 
    bean.on(root, 'click', '.fp-next', player.next);
@@ -96,9 +97,9 @@ flowplayer(function(player, root) {
          // stop to last clip, play button starts from 1:st clip
          } else {
 
-            // If we have multiple items in playlist, start from first
+            // If we have multiple items in playlist, start from the initial index (or the first)
             if (player.conf.playlist.length > 1) player.one("resume.fromfirst", function() {
-               player.play(0);
+               player.play(player.conf.playlist_index || 0);
                return false;
             });
          }
@@ -150,7 +151,7 @@ flowplayer(function(player, root) {
    if (player.conf.playlist.length) { // playlist configured by javascript, generate playlist
       playlistInitialized = true;
       generatePlaylist();
-      if (!player.conf.clip || !player.conf.clip.sources.length) player.conf.clip = player.conf.playlist[0];
+      if (!player.conf.clip || !player.conf.clip.sources.length) player.conf.clip = player.conf.playlist[player.conf.playlist_index || 0];
    }
 
    if (els().length && !playlistInitialized) { //generate playlist from existing elements
@@ -181,7 +182,7 @@ flowplayer(function(player, root) {
        if (!player.conf.playlist.length) return;
        var prev = active()[0],
           prevIndex = prev && prev.getAttribute('data-index'),
-          index = video.index = video.index || player.video.index || 0,
+          index = video.index = (video.index !== undefined ? video.index : (player.video.index !== undefined ? player.video.index : player.conf.playlist_index || 0)),
           el = common.find(conf.query +'[data-index="' + index + '"]', queryRoot())[0],
           is_last = index == player.conf.playlist.length - 1;
        if (prev) ClassList(prev).remove(klass);

--- a/lib/ext/playlist.js
+++ b/lib/ext/playlist.js
@@ -96,7 +96,7 @@ flowplayer(function(player, root) {
          // stop to last clip, play button starts from 1:st clip
          } else {
 
-            // If we have multiple items in playlist, start from the initial index (or the first)
+            // If we have multiple items in playlist, start from first
             if (player.conf.playlist.length > 1) player.one("resume.fromfirst", function() {
                player.play(0);
                return false;

--- a/lib/ext/playlist.js
+++ b/lib/ext/playlist.js
@@ -155,6 +155,7 @@ flowplayer(function(player, root) {
 
    if (els().length && !playlistInitialized) { //generate playlist from existing elements
        player.conf.playlist = [];
+       delete player.conf.startIndex;
        els().forEach(function(el) {
           var src = el.href;
           el.setAttribute('data-index', player.conf.playlist.length);


### PR DESCRIPTION
`startIndex` tells the player to start not at the first item of a playlist, but rather at an arbitrary index. 

This controls which clip is cued up first (either for immediate playback in the case of autoplay, or to be played first when the player is clicked).

Configuring a starting index rather than explicitly calling `play(index)` works better in non-autoplay scenarios, and avoids an extraneous "load" event for the 0th item.

Closes #973