### PR TITLE
Update html5.js

### DIFF
--- a/lib/engine/html5.js
+++ b/lib/engine/html5.js
@@ -121,7 +121,7 @@ engine = function(player, root) {
            common.prepend(container, api);
            created = true;
          } else if (!api) {
-           api = createVideoTag(video, !!video.autoplay || !!conf.autoplay, conf.clip.preload || 'metadata', false);
+           api = createVideoTag(video, !!video.autoplay || !!conf.autoplay, conf.clip.preload || conf.preload || 'metadata', false);
            common.prepend(container, api);
            created = true;
          } else {


### PR DESCRIPTION
if general conf has preload set, and no clip override is set then use the conf preload.
If both conf.preload and conf.clip.preload are not set then use 'metadata'