### PR TITLE
Grey out volume level in disabled state (#1017)

### DIFF
--- a/skin/styl/core/state.styl
+++ b/skin/styl/core/state.styl
@@ -131,6 +131,8 @@
    &.is-disabled
       .fp-progress
          background-color #9
+      .fp-volumelevel
+         background-color #80
    &.is-flash-disabled
      background-color #333
      object.fp-engine


### PR DESCRIPTION
Slightly darker color than for timeline to preserve a contrast to the
volume slider background.