### PR TITLE
Make iframe embed dimensions accept both numbers and strings (#997)

### DIFF
--- a/lib/ext/embed.js
+++ b/lib/ext/embed.js
@@ -30,7 +30,9 @@ flowplayer(function(player, root) {
        var src = player.conf.embed.iframe,
            width = embedConf.width || video.width || common.width(root),
            height = embedConf.height || video.height || common.height(root);
-       return '<iframe src="' + player.conf.embed.iframe + '" allowfullscreen style="width:' + width + 'px;height:' + height + 'px;border:none;"></iframe>';
+       if (!isNaN(width)) width += 'px';
+       if (!isNaN(height)) height += 'px';
+       return '<iframe src="' + player.conf.embed.iframe + '" allowfullscreen style="width:' + width + ';height:' + height + ';border:none;"></iframe>';
      }
      var props = ['ratio', 'rtmp', 'live', 'bufferTime', 'origin', 'analytics', 'key', 'subscribe', 'swf', 'swfHls', 'embed', 'adaptiveRatio', 'logo'];
      if (embedConf.playlist) props.push('playlist');


### PR DESCRIPTION
Users may have worked around #997, so do not break their setups, and
it's flexible at low cost.