### PR TITLE
html5 unload: prevent VOD files from continuing to buffer (#1025)

### DIFF
--- a/lib/engine/html5.js
+++ b/lib/engine/html5.js
@@ -188,7 +188,10 @@ engine = function(player, root) {
       },
 
       unload: function() {
-         common.find('video.fp-engine', root).forEach(common.removeNode);
+         common.find('video.fp-engine', root).forEach(function (videoTag) {
+           common.attr(videoTag, 'src', '');
+           common.removeNode(videoTag);
+         });
          if (!support.cachedVideoTag) videoTagCache = null;
          timer = clearInterval(timer);
          var instanceId = root.getAttribute('data-flowplayer-instance-id');


### PR DESCRIPTION
Empty video tag src attribute before removal.