### PR TITLE
Fix time format glitches (#1036)

### DIFF
--- a/lib/ext/ui.js
+++ b/lib/ext/ui.js
@@ -11,9 +11,14 @@ function zeropad(val) {
 }
 
 // display seconds in hh:mm:ss format
-function format(sec) {
+function format(sec, remaining) {
 
-   sec = sec || 0;
+   sec = Math.max(sec || 0, 0);
+   if (sec !== window.Infinity) {
+       sec = remaining ? Math.ceil(sec) : Math.floor(sec);
+   } else {
+       sec = 0;
+   }
 
    var h = Math.floor(sec / 3600),
        min = Math.floor(sec / 60);
@@ -183,7 +188,7 @@ flowplayer(function(api, root) {
       }
 
       common.html(elapsed, format(time));
-      common.html(remaining, '-' + format(duration - time));
+      common.html(remaining, '-' + format(duration - time, true));
 
    }).on("finish resume seek", function(e) {
       common.toggleClass(root, "is-finished", e.type == "finish");


### PR DESCRIPTION
- correct off by one (time + remaining resulting in (duration - 1)) by
  basing remaining seconds on Math.ceil(seconds) instead of Math.floor
- ensure that seconds to format are never negative
- replace Infinity with 0