### PR TITLE
Wrap buttons in a container

### DIFF
--- a/lib/ext/embed.js
+++ b/lib/ext/embed.js
@@ -15,11 +15,12 @@ flowplayer(function(player, root) {
 
    var conf = player.conf,
       ui = common.find('.fp-ui', root)[0],
+      btnContainer = common.find('.fp-buttons', root)[0],
       trigger = common.createElement('a', { "class": "fp-embed", title: 'Copy to your site'}),
       target = common.createElement('div',{ 'class': 'fp-embed-code'}, '<label>Paste this HTML code on your site to embed.</label><textarea></textarea>'),
       area = common.find("textarea", target)[0];
 
-   ui.appendChild(trigger);
+   common.prepend(btnContainer, trigger);
    ui.appendChild(target);
 
    player.embedCode = function() {

--- a/lib/ext/ui.js
+++ b/lib/ext/ui.js
@@ -44,8 +44,10 @@ flowplayer(function(api, root) {
    root.appendChild(common.createElement('div', {className: 'fp-ratio'}));
    var ui = common.createElement('div', {className: 'fp-ui'}, '\
          <div class="waiting"><em></em><em></em><em></em></div>\
-         <a class="fullscreen"></a>\
-         <a class="unload"></a>\
+         <div class="buttons">\
+           <a class="fullscreen"></a>\
+           <a class="unload"></a>\
+         </div>\
          <p class="speed"></p>\
          <div class="controls">\
             <a class="play"></a>\

--- a/skin/styl/core/buttons.styl
+++ b/skin/styl/core/buttons.styl
@@ -78,19 +78,19 @@
       .fixed-controls&
          bottom 15px
 
-
-   .fp-fullscreen, .fp-unload, .fp-close
+    .fp-buttons
       absolute spacing auto
       right spacing
-      block 30px 23px
+      .is-rtl&
+         right auto
+         left spacing
+
+   .fp-fullscreen, .fp-unload, .fp-close
+      display inline-block
       text-align center
       cursor pointer
       height controls_height
       width controls_height
-
-      .is-rtl&
-         right auto
-         left spacing
 
    .fp-unload, .fp-close
       display none
@@ -137,18 +137,7 @@
             display block
    &.is-ready.is-closeable
       .fp-unload
-         display block
-      .fp-embed
-          right (spacing * 3 + controls_height * 2)
-      .fp-fullscreen
-          right (spacing * 2 + controls_height)
-      &.is-rtl
-          .fp-embed
-            right auto
-            left (spacing * 3 + controls_height * 2)
-          .fp-fullscreen
-            right auto
-            left (spacing * 2 + controls_height)
+         display inline-block
    &.is-fullscreen
       .fp-fullscreen
          display block !important

--- a/skin/styl/core/buttons.styl
+++ b/skin/styl/core/buttons.styl
@@ -140,7 +140,6 @@
          display inline-block
    &.is-fullscreen
       .fp-fullscreen
-         display block !important
          &:before
           content "\e601"
 

--- a/skin/styl/core/embed.styl
+++ b/skin/styl/core/embed.styl
@@ -1,14 +1,9 @@
 
 .{root}
    .fp-embed
-      absolute spacing auto
-      right (spacing * 2 + controls_height)
       block controls_height controls_height
+      display inline-block
       text-align center
-
-      .is-rtl&
-         right auto
-         left (spacing * 2 + controls_height)
 
    .fp-embed-code
       position absolute
@@ -63,6 +58,8 @@
       .fp-embed, .fp-embed-code
          display block
          opacity 1
+      .fp-embed
+        display inline-block
 
    &.no-time .fp-embed
       left spacing !important

--- a/skin/styl/minimalist.styl
+++ b/skin/styl/minimalist.styl
@@ -28,30 +28,12 @@ controls = #0
    .fp-remaining, .fp-duration
      .no-brand&
        right right_margin
-   .fp-fullscreen, .fp-unload, .fp-close, .fp-embed
+   .fp-buttons
      right 0
      top 0
      .is-rtl&
        right auto
        left 0
-   .fp-embed
-     right controls_height + 2
-     .is-rtl&
-       right auto
-       left controls_height + 2
-   &.is-closeable.is-ready
-     .fp-fullscreen
-       right controls_height + 2
-     .fp-embed
-       right controls_height * 2 + 4
-     .is-rtl&
-       .fp-fullscreen
-         right auto
-         left controls_height + 2
-       .fp-embed
-         right auto
-         left controls_height * 2 + 4
-
 
    &.play-button
      play-button()


### PR DESCRIPTION
Wraps all (upper-right corner) buttons in a container.

It will be the only absolutely positioned element in the upper-right
corner.

All buttons inside the container will flow freely. This will allow us to
be more flexible in adding / removing buttons without gaps etc.