### PR TITLE
Ensure video.duration < Number.MAX_VALUE (#1036)

### DIFF
--- a/lib/engine/html5.js
+++ b/lib/engine/html5.js
@@ -260,7 +260,7 @@ engine = function(player, root) {
                case "ready":
 
                   arg = extend(video, {
-                     duration: api.duration,
+                     duration: api.duration < Number.MAX_VALUE ? api.duration : 0,
                      width: api.videoWidth,
                      height: api.videoHeight,
                      url: api.currentSrc,

--- a/lib/ext/ui.js
+++ b/lib/ext/ui.js
@@ -14,11 +14,7 @@ function zeropad(val) {
 function format(sec, remaining) {
 
    sec = Math.max(sec || 0, 0);
-   if (sec !== window.Infinity) {
-       sec = remaining ? Math.ceil(sec) : Math.floor(sec);
-   } else {
-       sec = 0;
-   }
+   sec = remaining ? Math.ceil(sec) : Math.floor(sec);
 
    var h = Math.floor(sec / 3600),
        min = Math.floor(sec / 60);


### PR DESCRIPTION
This is not only a display problem, the player may stall with some live
streams otherwise; so set duration to 0 on engine level if it is >=
Number.MAX_VALUE.

See:
https://github.com/flowplayer/flowplayer-mpegdash/commit/0392ad27fa56528b57e2e67222e9da620ca275b4