### PR TITLE
Make iframe embed code responsive if width and height not given (#804)

### DIFF
--- a/lib/ext/embed.js
+++ b/lib/ext/embed.js
@@ -29,10 +29,6 @@ flowplayer(function(player, root) {
      if (embedConf.iframe) {
        var width = embedConf.width || video.width || common.width(root),
            height = embedConf.height || video.height || common.height(root),
-           ctrlHeight = common.hasClass(root, 'fixed-controls')
-              ? common.height(common.find('.fp-controls', root)[0])
-              : common.hasClass(root, 'no-toggle') ? 0 : 4,
-           ratio = player.conf.ratio * 100,
            itrunc = '<iframe src="' + embedConf.iframe + '" allowfullscreen style="border:none;';
 
        if (embedConf.width || embedConf.height) {
@@ -40,8 +36,14 @@ flowplayer(function(player, root) {
           if (!isNaN(height)) height += 'px';
           return itrunc + 'width:' + width + 'px;height:' + height + 'px;"></iframe>';
        }
+       var ctrlHeight = common.hasClass(root, 'fixed-controls')
+              ? common.height(common.find('.fp-controls', root)[0])
+              : common.hasClass(root, 'no-toggle') ? 0 : 4,
+           ratio = player.conf.ratio;
+
        ctrlHeight = ctrlHeight ? 'padding-bottom:' + ctrlHeight + 'px;' : '';
-       return '<div style="position:relative;width:100%;display:inline-block;' + ctrlHeight + '">' + itrunc + 'position:absolute;top:0;left:0;width:100%;height:100%;"></iframe><div style="padding-top:' + ratio + '%;"></div></div>';
+       if (!ratio || player.conf.adaptiveRatio) ratio = height / width;
+       return '<div style="position:relative;width:100%;display:inline-block;' + ctrlHeight + '">' + itrunc + 'position:absolute;top:0;left:0;width:100%;height:100%;"></iframe><div style="padding-top:' + (ratio * 100) + '%;"></div></div>';
      }
      var props = ['ratio', 'rtmp', 'live', 'bufferTime', 'origin', 'analytics', 'key', 'subscribe', 'swf', 'swfHls', 'embed', 'adaptiveRatio', 'logo'];
      if (embedConf.playlist) props.push('playlist');

--- a/lib/ext/embed.js
+++ b/lib/ext/embed.js
@@ -27,12 +27,21 @@ flowplayer(function(player, root) {
          video = player.video;
 
      if (embedConf.iframe) {
-       var src = player.conf.embed.iframe,
-           width = embedConf.width || video.width || common.width(root),
-           height = embedConf.height || video.height || common.height(root);
-       if (!isNaN(width)) width += 'px';
-       if (!isNaN(height)) height += 'px';
-       return '<iframe src="' + player.conf.embed.iframe + '" allowfullscreen style="width:' + width + ';height:' + height + ';border:none;"></iframe>';
+       var width = embedConf.width || video.width || common.width(root),
+           height = embedConf.height || video.height || common.height(root),
+           ctrlHeight = common.hasClass(root, 'fixed-controls')
+              ? common.height(common.find('.fp-controls', root)[0])
+              : common.hasClass(root, 'no-toggle') ? 0 : 4,
+           ratio = player.conf.ratio * 100,
+           itrunc = '<iframe src="' + embedConf.iframe + '" allowfullscreen style="border:none;';
+
+       if (embedConf.width || embedConf.height) {
+          if (!isNaN(width)) width += 'px';
+          if (!isNaN(height)) height += 'px';
+          return itrunc + 'width:' + width + 'px;height:' + height + 'px;"></iframe>';
+       }
+       ctrlHeight = ctrlHeight ? 'padding-bottom:' + ctrlHeight + 'px;' : '';
+       return '<div style="position:relative;width:100%;display:inline-block;' + ctrlHeight + '">' + itrunc + 'position:absolute;top:0;left:0;width:100%;height:100%;"></iframe><div style="padding-top:' + ratio + '%;"></div></div>';
      }
      var props = ['ratio', 'rtmp', 'live', 'bufferTime', 'origin', 'analytics', 'key', 'subscribe', 'swf', 'swfHls', 'embed', 'adaptiveRatio', 'logo'];
      if (embedConf.playlist) props.push('playlist');


### PR DESCRIPTION
Arguably it would make sense to require both width and height configured
for a static layout. Especially height only will almost certainly lead
to strange results. Assume users know what they are doing when they
configure a dimension.