### PR TITLE
Enforce zoom: 1 for Flowplayer root element

### DIFF
--- a/skin/styl/core/player.styl
+++ b/skin/styl/core/player.styl
@@ -3,6 +3,8 @@
    position relative
    width 100%
 
+   zoom 1 !important
+
    counter-increment flowplayer
 
    // mobile friendly background images


### PR DESCRIPTION
Due to offset calculation problems in webkit (ank blink) based browsers
it becomes impossible to support CSS zoom for the player element.

Closes #1056