### PR TITLE
embed: omit bottom padding of container wrapper

### DIFF
--- a/lib/ext/embed.js
+++ b/lib/ext/embed.js
@@ -17,10 +17,10 @@ flowplayer(function(player, root) {
 
    player.embedCode = function() {
      var embedConf = player.conf.embed || {},
-         video = player.video;
-
-     var width = embedConf.width || video.width || common.width(root),
+         video = player.video,
+         width = embedConf.width || video.width || common.width(root),
          height = embedConf.height || video.height || common.height(root),
+         ratio = player.conf.ratio,
          itrunc = '<iframe src="' + player.shareUrl(true) + '" allowfullscreen style="border:none;';
 
      if (embedConf.width || embedConf.height) {
@@ -28,14 +28,9 @@ flowplayer(function(player, root) {
         if (!isNaN(height)) height += 'px';
         return itrunc + 'width:' + width + 'px;height:' + height + 'px;"></iframe>';
      }
-     var ctrlHeight = common.hasClass(root, 'fixed-controls')
-            ? common.height(common.find('.fp-controls', root)[0])
-            : common.hasClass(root, 'no-toggle') ? 0 : 4,
-         ratio = player.conf.ratio;
 
-     ctrlHeight = ctrlHeight ? 'padding-bottom:' + ctrlHeight + 'px;' : '';
      if (!ratio || player.conf.adaptiveRatio) ratio = height / width;
-     return '<div style="position:relative;width:100%;display:inline-block;' + ctrlHeight + '">' + itrunc + 'position:absolute;top:0;left:0;width:100%;height:100%;"></iframe><div style="padding-top:' + (ratio * 100) + '%;"></div></div>';
+     return '<div style="position:relative;width:100%;display:inline-block;">' + itrunc + 'position:absolute;top:0;left:0;width:100%;height:100%;"></iframe><div style="padding-top:' + (ratio * 100) + '%;"></div></div>';
    };
 
    bean.on(root, 'click', '.fp-embed', function() {


### PR DESCRIPTION
fp7 does not feature:
- slim timeline (4px)
- fixed-controls modifier (controlbar height below player area)

So bottom padding of container wrapper is never needed.