### PR TITLE
Simplify HTML5 engine load

### DIFF
--- a/lib/engine/html5.js
+++ b/lib/engine/html5.js
@@ -73,8 +73,8 @@ var createVideoTag = function(video, autoplay, preload, useCache) {
   el.src = video.src;
   el.type = getType(video.type);
   el.className = 'fp-engine';
-  el.autoplay = autoplay ? 'autoplay' : false;
-  el.preload = preload;
+  if (flowplayer.support.autoplay) el.autoplay = autoplay ? 'autoplay' : false;
+  if (flowplayer.support.dataload) el.preload = preload;
   el.setAttribute('webkit-playsinline', 'true');
   el.setAttribute('playsinline', 'true');
   if (useCache) videoTagCache = el;
@@ -115,15 +115,13 @@ engine = function(player, root) {
       },
 
       load: function(video) {
-         var created = false, container = common.find('.fp-player', root)[0], reload = false;
+         var container = common.find('.fp-player', root)[0], reload = false;
          if (conf.splash && !api) {
            api = createVideoTag(video);
            common.prepend(container, api);
-           created = true;
          } else if (!api) {
            api = createVideoTag(video, !!video.autoplay || !!conf.autoplay, conf.clip.preload || 'metadata', false);
            common.prepend(container, api);
-           created = true;
          } else {
            common.addClass(api, 'fp-engine');
            common.find('source,track', api).forEach(common.removeNode);
@@ -161,13 +159,8 @@ engine = function(player, root) {
 
          self._listeners = listen(api, common.find("source", api).concat(api), video) || self._listeners;
 
-         // iPad (+others?) demands load()
-         if (conf.clip.preload != 'none' && video.type != "mpegurl" || !support.zeropreload || !support.dataload) api.load();
-         if (created || reload) api.load();
-         if (api.paused && (video.autoplay || conf.autoplay)) api.play();
-         if (!support.dataload && conf.live || video.live) setTimeout(function() {
-           api.play(); // iPad sometimes needs additional play on live clips
-         });
+        if (reload) api.load();
+        if (api.paused && (video.autoplay || conf.autoplay || conf.splash)) api.play();
       },
 
       pause: function() {
@@ -257,7 +250,6 @@ engine = function(player, root) {
       if (typeof api.textTracks.addEventListener === 'function') api.textTracks.addEventListener('addtrack', function(tev) {
         listenMetadata(tev.track);
       }, false);
-
       if (player.conf.live || player.live || video.live) {
         bean.on(api, 'progress.dvrhack', function() {
           if (!api.seekable.length) return;

--- a/lib/ext/support.js
+++ b/lib/ext/support.js
@@ -69,8 +69,8 @@ var flowplayer = require('../flowplayer'),
         inlineVideo: (!IS_IPHONE || IOS_VER >= 10) && (!IS_WP || (WP_VER >= 8.1 && IE_MOBILE_VER >= 11)) && (!IS_ANDROID || ANDROID_VER >= 3),
         hlsDuration: !IS_ANDROID && (!b.safari || IS_IPAD || IS_IPHONE || IS_IPAD_CHROME),
         seekable: !IS_IPAD && !IS_IPAD_CHROME
-    });
-
+   });
+   s.autoplay = s.firstframe;
    // flashVideo
    try {
       var plugin = navigator.plugins["Shockwave Flash"],

--- a/test/dvr.html
+++ b/test/dvr.html
@@ -1,0 +1,47 @@
+
+<!doctype html>
+
+<head>
+   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+   <!-- player skin -->
+   <link rel="stylesheet" type="text/css" href="../dist/skin/skin.css?f">
+
+   <!-- site specific styling -->
+   <style>
+   body { font-family: avenir, sans-serif; max-width: 1000px; margin: 0 auto; padding: .6em;}
+   .flowplayer { width: 100%; }
+   </style>
+
+   <!-- flowplayer depends on jQuery 1.7.1+ (for now) -->
+   <script src="http://ajax.googleapis.com/ajax/libs/jquery/1/jquery.js"></script>
+
+   <!-- include flowplayer -->
+   <script src="../dist/flowplayer.js?i"></script>
+
+</head>
+
+<body>
+
+   <!-- the player -->
+   <div class="flowplayer"
+      data-swf="../dist/flowplayer.swf"
+      data-swf-hls="../dist/flowplayerhls.swf"
+      data-dvr="true"
+      data-aspect-ratio="40:23">
+
+     <video>
+        <source type="application/x-mpegurl" src="http://stream.novascotiawebcams.com/live-origin/whitepointbeach/playlist.m3u8?DVR">
+        <source type="application/x-mpegurl" src="//wowza.jwplayer.com/live/jelly.stream/playlist.m3u8?DVR">
+      </video>
+
+   </div>
+
+   <script>
+   $(function() {
+   flowplayer().on('dvrwindow', function(ev, api, d) {
+     console.log('dvrwindow', d);
+   });
+   });
+   </script>
+</body>
+


### PR DESCRIPTION
 * Don't use autoplay where it can't be used
 * Don't use preload where it does not make any sense
 * Only call `load()` and `play()` on video tag when really needed

Fixes #1104