### PR TITLE
Race condition - cuepointsDisabled

### DIFF
--- a/lib/ext/cuepoint.js
+++ b/lib/ext/cuepoint.js
@@ -35,9 +35,7 @@ flowplayer(function(player, root) {
 
    }).on("unload", setClass)
    .on('beforeseek', function(ev) {
-     setTimeout(function() {
-       if (!ev.defaultPrevented) cuepointsDisabled = true;
-     });
+     if (!ev.defaultPrevented) cuepointsDisabled = true;
    }).on("seek", function(ev, api, time) {
      setClass();
      lastFiredSegment = segmentForCue(time || 0) - 0.125;


### PR DESCRIPTION
Fixes race condition whereby cuepointsDisabled can be incorrectly set to true due to the 'seek' event executing prior to the body of the setTimeout call in the 'beforeseek' event.

Race condition mainly occurs when replaying the same video through a call to api.seek(0)