### PR TITLE
bar-slider: bean.fire third argument must be array

### DIFF
--- a/lib/ext/ui/bar-slider.js
+++ b/lib/ext/ui/bar-slider.js
@@ -22,7 +22,7 @@ function slider(root, opts) {
         common.toggleClass(bar, activeClass, active);
         common.toggleClass(bar, inactiveClass, !active);
       });
-      if (trigger) bean.fire(root, 'slide', to);
+      if (trigger) bean.fire(root, 'slide', [ to ]);
     },
     disable: function(flag) {
       disabled = flag;


### PR DESCRIPTION
Otherwise
flowplayer().sliders.volume.slide(0, true)
will throw:
Uncaught TypeError: Failed to set the 'volume' property on
'HTMLMediaElement': The provided double value is non-finite.

See:
https://flowplayer.org/forum/#!/setup:nan-exception-on-setting-vo