### PR TITLE
Do not indicate speed rate change when playback starts

### DIFF
--- a/lib/ext/ui.js
+++ b/lib/ext/ui.js
@@ -232,21 +232,23 @@ flowplayer(function(api, root) {
       if (max < 1) common.css(buffer, "width", (max * 100) + "%");
       else common.css(buffer, 'width', '100%');
    }).on("speed", function(e, api, val) {
-     common.text(speedFlash, val + "x");
-     common.addClass(speedFlash, 'fp-shown');
-     speedAnimationTimers = speedAnimationTimers.filter(function(to) {
-       clearTimeout(to);
-       return false;
-     });
-     speedAnimationTimers.push(setTimeout(function() {
-      common.addClass(speedFlash, 'fp-hilite');
-      speedAnimationTimers.push(setTimeout(function() {
-        common.removeClass(speedFlash, 'fp-hilite');
+     if (api.video.time) {
+       common.text(speedFlash, val + "x");
+       common.addClass(speedFlash, 'fp-shown');
+       speedAnimationTimers = speedAnimationTimers.filter(function(to) {
+         clearTimeout(to);
+         return false;
+       });
+       speedAnimationTimers.push(setTimeout(function() {
+        common.addClass(speedFlash, 'fp-hilite');
         speedAnimationTimers.push(setTimeout(function() {
-          common.removeClass(speedFlash, 'fp-shown');
-        }, 300));
-      }, 1000));
-     }));
+          common.removeClass(speedFlash, 'fp-hilite');
+          speedAnimationTimers.push(setTimeout(function() {
+            common.removeClass(speedFlash, 'fp-shown');
+          }, 300));
+        }, 1000));
+       }));
+     }
 
    }).on("buffered", function() {
      common.css(buffer, 'width', '100%');


### PR DESCRIPTION
With the prominent Flowplayer 7 speed flash, the initial "1x" in Firefox
is very annoying.
But with Flowplayer 7 and in recent Firefox, not firing speed flash when
video.time is 0 seems to avoid most cases.

refs #385
supersedes https://github.com/flowplayer/flowplayer/pull/541

See also:
https://flowplayer.org/forum/#!/setup:firefox-showing-1x