### PR TITLE
dvr: display timestamp (#1137)

### DIFF
--- a/lib/ext/ui.js
+++ b/lib/ext/ui.js
@@ -376,7 +376,9 @@ flowplayer(function(api, root) {
      var x = ev.pageX || ev.clientX,
          delta = x - common.offset(timeline).left,
          percentage = delta / common.width(timeline),
-         seconds = (api.rtl ? 1 - percentage : percentage) * api.video.duration;
+         video = api.video,
+         duration = video.duration - (video.seekOffset === undefined ? 0 : video.seekOffset),
+         seconds = (api.rtl ? 1 - percentage : percentage) * duration;
      if (percentage < 0) return;
      common.html(timelineTooltip, format(seconds));
      var left = (delta - common.width(timelineTooltip) / 2);

--- a/skin/sass/state.sass
+++ b/skin/sass/state.sass
@@ -109,8 +109,6 @@
       &.is-live-position
         .fp-duration
           color: #00abcd
-    .fp-timestamp
-      display: none !important
   &.is-flash-disabled
     .fp-waiting
       display: none !important


### PR DESCRIPTION
The timestamp is especially informative for DVR as it can show the
current or desired position inside the DVR window. So show it.

The CSS hiding of the timestamp for live (not dvr) can be omitted. It
was redundant anyway because is-live hides the timeline, and therefore
one cannot mousemove over it.