### PR TITLE
native hls live: do not seek to 0 on stop (#1189)

### DIFF
--- a/lib/flowplayer.js
+++ b/lib/flowplayer.js
@@ -439,9 +439,13 @@ function initializePlayer(element, opts, callback) {
          stop: function() {
             if (api.ready) {
                api.pause();
-               api.seek(0, function() {
+               if (!api.live || api.dvr) {
+                  api.seek(0, function() {
+                     api.trigger("stop", [api]);
+                  });
+               } else {
                   api.trigger("stop", [api]);
-               });
+               }
             }
             return api;
          },


### PR DESCRIPTION
In part this also solves #844: poster functionality works, instead of
video not loading.