### PR TITLE
ffmpeg restart problem. The toolbar remains visible after ffmpeg restarts

### DIFF
--- a/lib/as/NetStreamProvider.as
+++ b/lib/as/NetStreamProvider.as
@@ -268,7 +268,7 @@ public class NetStreamProvider implements StreamProvider {
 
         private function setupStream(conn : NetConnection) : void {
             player.debug("setupStream() ", {ready:ready, preloadCompete:preloadComplete, paused:paused, autoplay:conf.autoplay});
-
+            var stopTracker : Timer;
             netStream = new NetStream(conn);
             var bufferTime : Number = conf.hasOwnProperty("bufferTime") ? conf.bufferTime : conf.live ? 0 : 3;
             player.debug("bufferTime == " + bufferTime);
@@ -341,6 +341,10 @@ public class NetStreamProvider implements StreamProvider {
                                 paused = false;
                             }
                         }
+                        // Stop the stop timer and cancel
+                        if (stopTracker && stopTracker.running) {
+                            stopTracker.stop();
+                        }
                         break;
                     case "NetStream.Seek.Notify":
                         finished = false;
@@ -358,7 +362,7 @@ public class NetStreamProvider implements StreamProvider {
                         player.fire(Flowplayer.ERROR, {code:4});
                         break;
                     case "NetStream.Play.Stop":
-                        var stopTracker : Timer = new Timer(100);
+                        stopTracker = new Timer(100);
                         var prevTime : Number = 0;
                         if (stopTracker && stopTracker.running) return;
                         stopTracker.addEventListener(TimerEvent.TIMER, function(e : TimerEvent) : void {

--- a/lib/as/NetStreamProvider.as
+++ b/lib/as/NetStreamProvider.as
@@ -341,7 +341,7 @@ public class NetStreamProvider implements StreamProvider {
                                 paused = false;
                             }
                         }
-                        // Stop the stop timer and cancel
+                        // Stop the stop timer if it's running
                         if (stopTracker && stopTracker.running) {
                             stopTracker.stop();
                         }


### PR DESCRIPTION
When ffmpeg stops and then restarts, the video is playing correctly but the toolbar remains visible on the screen and can't be removed.
The problem is the same in the 6.0.5 version but with the Play button on the middle of the screen.

See forum entry: 'Play button remains on the screen after ffmpeg restarts'
And support ticket: [Ticket#2017071381000762] ID 270071. Following up from forum post thread 'Play button remains on the screen after ffmpeg restarts.

