### PR TITLE
Fix problem when video resolution changed. Handle the NetStream.Video.DimensionChange event (II)Handle the NetStream.Video.DimensionChange event

### DIFF
--- a/lib/as/NetStreamProvider.as
+++ b/lib/as/NetStreamProvider.as
@@ -333,6 +333,9 @@ public class NetStreamProvider implements StreamProvider {
                 if (conf.debug) player.fire("NetStatusEvent: ", e.info.code);
 
                 switch (e.info.code) {
+                    case "NetStream.Video.DimensionChange":
+                        player.resize();
+                        break;
                     case "NetStream.Play.Start":
                         finished = false;
                         // RTMP fires start a lot


### PR DESCRIPTION
When video resolution changes and the stream is already playing, the NetStream.Video.DimensionChange event is received in the NetStreamProvider.as .
Currently this event handler is not being used and the video player is not resized accordingly.
See forum entry: https://flowplayer.com/forum/#!/skinning_css:wrong-video-size-picked-by