### PR TITLE
Fix bug for non-ASCII characters in config

### DIFF
--- a/lib/ext/share.js
+++ b/lib/ext/share.js
@@ -16,7 +16,9 @@ flowplayer(function(api, root) {
     if (directEmbed && c.embed && c.embed.iframe) return c.embed.iframe;
     if (typeof api.conf.share === 'string') return api.conf.share;
     var title = encodeURIComponent(api.video.title || (common.find('title')[0] || {}).innerHTML || 'Flowplayer video')
-      , conf = encodeURIComponent(btoa(JSON.stringify(extend({}, api.conf, api.extensions))))
+      , conf = encodeURIComponent(btoa(JSON.stringify(extend({}, api.conf, api.extensions)).replace(/[\u007F-\uFFFF]/g, function(chr) {
+    return "\\u" + ("0000" + chr.charCodeAt(0).toString(16)).substr(-4)
+})))
       , redirect = encodeURIComponent(window.location.toString())
       , baseUrl = directEmbed ? 'https://flowplayer.org/e/' : 'https://flowplayer.org/s/';
     return baseUrl + '?t=' + title + '&c=' + conf + '&r=' + redirect;


### PR DESCRIPTION
when there is a non-ASCII (for example utf-8) characters in configs btoa has an error. with escaping them this problem will be fixed