### PR TITLE
Make first field of subtitle TIMECODE_RE less strict (#1237)

### DIFF
--- a/lib/ext/subtitles/parser.js
+++ b/lib/ext/subtitles/parser.js
@@ -1,5 +1,5 @@
 module.exports = function(txt) {
-  var TIMECODE_RE = /^(([0-9]{2}:){1,2}[0-9]{2}[,.][0-9]{3}) --\> (([0-9]{2}:){1,2}[0-9]{2}[,.][0-9]{3})(.*)/;
+  var TIMECODE_RE = /^(([0-9]+:){1,2}[0-9]{2}[,.][0-9]{3}) --\> (([0-9]+:){1,2}[0-9]{2}[,.][0-9]{3})(.*)/;
 
   function seconds(timecode) {
      var els = timecode.split(':');


### PR DESCRIPTION
Allows the following to pass:

- while the hours field must have at least 2 digits, some real world vtt
  have only one
- hours > 99

For simplicity of pattern also allows single digit minutes, while still
requiring the field.