### PR TITLE
Revisit Android client detection (#1249)

### DIFF
--- a/lib/ext/mobile.js
+++ b/lib/ext/mobile.js
@@ -14,10 +14,11 @@ if (flowplayer.support.touch || isIeMobile) {
 
       // custom load for android
       if (isAndroid && !isIeMobile) {
-         if (!/Chrome/.test(UA) && androidVer < 4) {
+         if (!/Chrome/.test(UA) && androidVer < 4 || /SAMSUNG/.test(UA) && androidVer < 5) {
             var originalLoad = player.load;
             player.load = function() {
                var ret = originalLoad.apply(player, arguments);
+               common.find('.fp-engine', root)[0].load();
                player.trigger('ready', [player, player.video]);
                return ret;
             };
@@ -82,7 +83,7 @@ if (flowplayer.support.touch || isIeMobile) {
         if (!player.playing && !player.splash && common.hasClass(root, 'is-mouseout') && !common.hasClass(root, 'is-mouseover')) {
           setTimeout(function() {
             if (!player.disabled && !player.playing && !player.splash) {
-              player.resume();
+              common.find(root, '.fp-engine')[0].play();
             }
           }, 400);
         }
@@ -124,7 +125,7 @@ if (flowplayer.support.touch || isIeMobile) {
             bean.one(video, 'canplay', function() {
                video.play();
             });
-            video.play();
+            video.load();
          }
 
          player.bind("progress.dur", function() {

--- a/lib/ext/mobile.js
+++ b/lib/ext/mobile.js
@@ -4,17 +4,19 @@ var flowplayer = require('../flowplayer'),
     common = require('../common'),
     bean = require('bean'),
     format = require('./ui').format,
+    support = flowplayer.support,
     UA = window.navigator.userAgent;
-if (flowplayer.support.touch || isIeMobile) {
+if (support.touch || isIeMobile) {
 
    flowplayer(function(player, root) {
-      var isAndroid = /Android/.test(UA) && !/Firefox|Opera/.test(UA),
+      var android = support.android,
+          isAndroid = android && !android.firefox,
           isSilk = /Silk/.test(UA),
-          androidVer = isAndroid ? parseFloat(/Android\ (\d\.\d)/.exec(UA)[1], 10) : 0;
+          androidVer = android.version || 0;
 
       // custom load for android
       if (isAndroid && !isIeMobile) {
-         if (!/Chrome/.test(UA) && androidVer < 4 || /SAMSUNG/.test(UA) && androidVer < 5) {
+         if (!/Chrome/.test(UA) && androidVer < 4 || android.samsung && androidVer < 5) {
             var originalLoad = player.load;
             player.load = function() {
                var ret = originalLoad.apply(player, arguments);
@@ -30,16 +32,16 @@ if (flowplayer.support.touch || isIeMobile) {
              api.trigger('progress', [api, currentTime]);
            }, 1000);
          };
-         player.bind('ready pause unload', function() {
+         player.on('ready pause unload', function() {
            if (timer) {
              clearInterval(timer);
              timer = null;
            }
          });
-         player.bind('ready', function() {
+         player.on('ready', function() {
            currentTime = 0;
          });
-         player.bind('resume', function(ev, api) {
+         player.on('resume', function(ev, api) {
            if (!api.live) return;
            if (currentTime) { return resumeTimer(api); }
            player.one('progress', function(ev, api, t) {
@@ -51,7 +53,7 @@ if (flowplayer.support.touch || isIeMobile) {
       }
 
       // hide volume
-      if (!flowplayer.support.volume) {
+      if (!support.volume) {
         common.removeClass(root, 'fp-mute');
         common.addClass(root, 'no-volume');
       }
@@ -92,7 +94,7 @@ if (flowplayer.support.touch || isIeMobile) {
       });
 
       // native fullscreen
-      if (!flowplayer.support.fullscreen && player.conf.native_fullscreen && typeof document.createElement('video').webkitEnterFullScreen === 'function') {
+      if (!support.fullscreen && player.conf.native_fullscreen && typeof common.createElement('video').webkitEnterFullScreen === 'function') {
          var oldFullscreen = player.fullscreen;
          player.fullscreen = function() {
             var video = common.find('video.fp-engine', root)[0];

--- a/lib/ext/mobile.js
+++ b/lib/ext/mobile.js
@@ -8,7 +8,7 @@ var flowplayer = require('../flowplayer'),
 if (flowplayer.support.touch || isIeMobile) {
 
    flowplayer(function(player, root) {
-      var isAndroid = /Android/.test(UA) && !/Firefox/.test(UA) && !/Opera/.test(UA),
+      var isAndroid = /Android/.test(UA) && !/Firefox|Opera/.test(UA),
           isSilk = /Silk/.test(UA),
           androidVer = isAndroid ? parseFloat(/Android\ (\d\.\d)/.exec(UA)[1], 10) : 0;
 

--- a/lib/ext/support.js
+++ b/lib/ext/support.js
@@ -41,8 +41,9 @@ var flowplayer = require('../flowplayer'),
       IS_IPAD = /iPad|MeeGo/.test(UA) && !/CriOS/.test(UA),
       IS_IPAD_CHROME = /iPad/.test(UA) && /CriOS/.test(UA),
       IS_IPHONE = /iP(hone|od)/i.test(UA) && !/iPad/.test(UA) && !/IEMobile/i.test(UA),
-      IS_ANDROID = /Android/.test(UA) && !/Firefox/.test(UA),
-      IS_ANDROID_FIREFOX = /Android/.test(UA) && /Firefox/.test(UA),
+      IS_ANDROID = /Android/.test(UA),
+      IS_ANDROID_FIREFOX = IS_ANDROID && /Firefox/.test(UA),
+      IS_ANDROID_SAMSUNG = IS_ANDROID && /SAMSUNG/.test(UA),
       IS_SILK = /Silk/.test(UA),
       IS_WP = /IEMobile/.test(UA),
       WP_VER = IS_WP ? parseFloat(/Windows\ Phone\ (\d+\.\d+)/.exec(UA)[1], 10) : 0,
@@ -75,8 +76,11 @@ var flowplayer = require('../flowplayer'),
         zeropreload: !IS_IE && !IS_ANDROID, // IE supports only preload=metadata
         volume: !IS_IPAD && !IS_IPHONE && !IS_SILK && !IS_IPAD_CHROME,
         cachedVideoTag: !IS_IPAD && !IS_IPHONE && !IS_IPAD_CHROME && !IS_WP,
-        firstframe: !IS_SILK && !IS_WP && !IS_ANDROID_FIREFOX && !(IOS_VER && IOS_VER < 10) && !(IS_ANDROID && ANDROID_VER < 4.4),
-        mutedAutoplay: (IS_IPHONE || IS_IPAD || IS_IPAD_CHROME) && IOS_VER >=10 || IS_ANDROID && ANDROID_VER > 4.3,
+        // iOS < 10 and Samsung support firstframe but not mutedAutoplay
+        // pretend lacking firstframe support because so far we treat
+        // support.autoplay as synonym of support.firstframe
+        firstframe: !IS_SILK && !IS_WP && !IS_ANDROID_FIREFOX && !IS_ANDROID_SAMSUNG && !(IOS_VER && IOS_VER < 10) && !(IS_ANDROID && ANDROID_VER < 4.4),
+        mutedAutoplay: (IS_IPHONE || IS_IPAD || IS_IPAD_CHROME) && IOS_VER >=10 || IS_ANDROID && ANDROID_VER > 4.3 && !IS_ANDROID_SAMSUNG,
         inlineVideo: (!IS_IPHONE || IOS_VER >= 10) && (!IS_WP || (WP_VER >= 8.1 && IE_MOBILE_VER >= 11)) && (!IS_ANDROID || ANDROID_VER >= 3),
         hlsDuration: !IS_ANDROID && (!b.safari || IS_IPAD || IS_IPHONE || IS_IPAD_CHROME),
         seekable: !IS_IPAD && !IS_IPAD_CHROME

--- a/lib/ext/support.js
+++ b/lib/ext/support.js
@@ -61,6 +61,8 @@ var flowplayer = require('../flowplayer'),
         },
         android: IS_ANDROID ? {
           firefox: IS_ANDROID_FIREFOX,
+          opera: /Opera/.test(UA),
+          samsung: IS_ANDROID_SAMSUNG,
           version: ANDROID_VER
         } : false,
         subtitles: !!video.addTextTrack,

--- a/lib/flowplayer.js
+++ b/lib/flowplayer.js
@@ -533,9 +533,11 @@ function initializePlayer(element, opts, callback) {
 
 
          api.on('boot', function() {
+            var support = flowplayer.support;
 
             // splash
-            if (conf.splash || common.hasClass(root, "is-splash") || !flowplayer.support.firstframe) {
+            if (conf.splash || common.hasClass(root, "is-splash") ||
+                  !support.firstframe && !(support.mutedAutoplay && conf.autoplay)) {
                api.forcedSplash = !conf.splash && !common.hasClass(root, "is-splash");
                api.splash = conf.autoplay = true;
                if (!conf.splash) conf.splash = true;


### PR DESCRIPTION
- support.android now applies to all clients on Android, including
  Firefox; support.android.firefox now returns true in Firefox
- Samsung stock browser now properly detected
- Android Firefox does not support firstframe setups, but mutedAutoplay:
  do not enforce splash when autoplay is given, so it can autoplay,
  while enforcing splash for firstframe
- Samsung stock browser supports firstframe, but not mutedAutoplay:
  make it behave exactly like iOS < 10 by pretending it does not support
  firstframe - this is above all for consistency: so far we treat
  support.autoplay as synonym of support.firstframe

TODO: Android Opera
Is currently treated like Android Chrome except in one place. May need
further special casing.