### PR TITLE
Ensure buffered property has length (#1325)

### DIFF
--- a/lib/flowplayer.js
+++ b/lib/flowplayer.js
@@ -651,7 +651,7 @@ function initializePlayer(element, opts, callback) {
          }).on("progress", function(e, api, time) {
             api.video.time = time;
          }).on('buffer', function(e, api, buffered) {
-            api.video.buffer = typeof buffered === 'number' ? buffered : buffered[buffered.length - 1].end;
+            api.video.buffer = typeof buffered === 'number' ? buffered : buffered.length ? buffered[buffered.length - 1].end : 0;
          }).on("speed", function(e, api, val) {
             api.currentSpeed = val;
 


### PR DESCRIPTION
Fail over to 0 otherwise.
Avoids type error in desktop Safari with empty cache in many autoplay
scenarios.