### PR TITLE
added support for bufferTimeMax

### DIFF
--- a/lib/as/NetStreamProvider.as
+++ b/lib/as/NetStreamProvider.as
@@ -362,10 +362,6 @@ public class NetStreamProvider implements StreamProvider {
                         if (stopTracker && stopTracker.running) {
                             stopTracker.stop();
                         }
-                        player.debug("workaround for missing metadata");
-                        ready = true;
-                        player.fire(Flowplayer.READY, {seekable:!!conf.rtmp, bytes:netStream.bytesTotal, src:stream, url:stream});
-                        player.fire(Flowplayer.RESUME, null);
                         break;
                     case "NetStream.Seek.Notify":
                         finished = false;

--- a/lib/as/NetStreamProvider.as
+++ b/lib/as/NetStreamProvider.as
@@ -26,9 +26,7 @@ package {
     import flash.net.NetConnection;
     import flash.net.NetStream;
     import flash.utils.Timer;
-
-    import flash.utils.setTimeout;
-    import flash.utils.setInterval;
+import flash.utils.setTimeout;
 
 public class NetStreamProvider implements StreamProvider {
         // flashvars
@@ -49,7 +47,6 @@ public class NetStreamProvider implements StreamProvider {
         private var player : Flowplayer;
         private var _video : Video;
 
-        private var intervalMonitorBufferLengthEverySecond:uint;
         public function NetStreamProvider(player : Flowplayer, video : Video) {
             this.player = player;
             this._video = video;
@@ -269,17 +266,10 @@ public class NetStreamProvider implements StreamProvider {
             }
         }
 
-        private function monPlayback():void {
-            player.debug("bufferLength: " + netStream.bufferLength);
-        }
-
         private function setupStream(conn : NetConnection) : void {
             player.debug("setupStream() ", {ready:ready, preloadCompete:preloadComplete, paused:paused, autoplay:conf.autoplay});
             var stopTracker : Timer;
             netStream = new NetStream(conn);
-
-            intervalMonitorBufferLengthEverySecond = setInterval(monPlayback, 1000);
-
             var bufferTime : Number = conf.hasOwnProperty("bufferTime") ? conf.bufferTime : conf.live ? 0 : 3;
             player.debug("bufferTime == " + bufferTime);
             netStream.bufferTime = bufferTime;

--- a/lib/engine/flash.js
+++ b/lib/engine/flash.js
@@ -124,8 +124,9 @@ engineImpl = function flashEngine(player, root) {
 
             var hlsQualities = typeof video.hlsQualities !== 'undefined' ? video.hlsQualities : conf.hlsQualities;
             if (typeof hlsQualities !== 'undefined') opts.hlsQualities = hlsQualities ? encodeURIComponent(JSON.stringify(hlsQualities)) : hlsQualities;
-            // bufferTime might be 0
+            // bufferTime, bufferTimeMax might be 0
             if (conf.bufferTime !== undefined) opts.bufferTime = conf.bufferTime;
+            if (conf.bufferTimeMax !== undefined) opts.bufferTimeMax = conf.bufferTimeMax;
 
             if (is_absolute) delete opts.rtmp;
 


### PR DESCRIPTION
We've seen that when playing live RTMP streams we can end up where the latency keeps growing and never recovers.

This is especially true using a small value for bufferTime to act as a jitter buffer since a non-zero bufferTime sets the NetStream in non-live mode which has quite different behaviour to live. However we've also seen this in live mode when due to network conditions you can end up with a large latency which never recovers.

Having the option to set bufferTimeMax allows a latency limit to be set. Once this limit has been crossed the flash will catch up by playing faster until the original bufferTime value has been reached.
https://help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/flash/net/NetStream.html#bufferTimeMax

It would be better for our use case if there was an option to flush the buffer if it gets too large but I can't see any way to do that when using bufferTime !== 0.