### PR TITLE
moved event ERROR outside event MANIFEST_PARSED

### DIFF
--- a/lib/engine/hlsjs.js
+++ b/lib/engine/hlsjs.js
@@ -153,24 +153,25 @@ engine = function(player, root) {
 
       // End quality selection
 
-      hls.on(Hls.Events.ERROR, function(ev, data) {
-        if (!data.fatal) return;
-        if (conf.recoverNetworkError && data.type === Hls.ErrorTypes.NETWORK_ERROR) recover(true);
-        else if (conf.recoverMediaError && data.type === Hls.ErrorTypes.MEDIA_ERROR) recover(false);
-        else {
-          var code = 5;
-          if (data.type === Hls.ErrorTypes.NETWORK_ERROR) code = 2;
-          if (data.type === Hls.ErrorTypes.MEDIA_ERROR) code = 3;
-          hls.destroy();
-          player.trigger('error', [player, { code: code }]);
-        }
-      });
-
       hls.attachMedia(api);
 
       if (lastSource && video.src !== lastSource) api.play();
       lastSource = video.src;
     });
+    
+    hls.on(Hls.Events.ERROR, function(ev, data) {
+      if (!data.fatal) return;
+      if (conf.recoverNetworkError && data.type === Hls.ErrorTypes.NETWORK_ERROR) recover(true);
+      else if (conf.recoverMediaError && data.type === Hls.ErrorTypes.MEDIA_ERROR) recover(false);
+      else {
+        var code = 5;
+        if (data.type === Hls.ErrorTypes.NETWORK_ERROR) code = 2;
+        if (data.type === Hls.ErrorTypes.MEDIA_ERROR) code = 3;
+        hls.destroy();
+        player.trigger('error', [player, { code: code }]);
+      }
+    });
+    
     return {
       handlers: {
         error: function(e, videoTag) {


### PR DESCRIPTION
Hls.Events.ERROR should handle events there manifest can not be parsed like then m3u8 file can not be found. Those events occurs before Hls.Events.MANIFEST_PARSED has been triggered. 