### PR TITLE
Make Android UA detection robust to new versions

### DIFF
--- a/lib/ext/support.js
+++ b/lib/ext/support.js
@@ -51,7 +51,7 @@ var flowplayer = require('../flowplayer'),
       WP_VER = IS_WP ? parseFloat(/Windows\ Phone\ (\d+\.\d+)/.exec(UA)[1], 10) : 0,
       IE_MOBILE_VER = IS_WP ? parseFloat(/IEMobile\/(\d+\.\d+)/.exec(UA)[1], 10) : 0,
       IOS_VER = IS_IPAD || IS_IPHONE ? parseIOSVersion(UA) : 0,
-      ANDROID_VER = IS_ANDROID ? parseFloat(/Android\ (\d\.\d)/.exec(UA)[1], 10) : 0;
+      ANDROID_VER = IS_ANDROID ? parseFloat(/Android\ (\d+(\.\d+)?)/.exec(UA)[1], 10) : 0;
 
    var ios = (IS_IPHONE || IS_IPAD || IS_IPAD_CHROME) && {
      iPhone: IS_IPHONE,


### PR DESCRIPTION
Android 9 is now shipping to Pixel phones, and the Flowplayer plugin crashes on load on this version.
This is due to the user agent regex used to parse the Android version failing to match, and a `null` match set being dereferenced.
The regex assumes that both major and minor version numbers are present, e.g. `Android 8.1`, whereas the UA string for Android 9 just contains `Android 9`.
This change makes the minor version portion of the string optional in the match.

Also, the regex assumes a single digit for each component of the version number, meaning that it will also break for Android 10 user agent strings, when they appear.
This change makes the regex accept multi-digit version numbers as well.

Fixes #1404.