### PR TITLE
Patching wrong Facebook Share URL --> Current is not working on mobile!

### DIFF
--- a/lib/ext/facebook.js
+++ b/lib/ext/facebook.js
@@ -24,7 +24,7 @@ flowplayer(function(api, root) {
       top = Math.round((winHeight / 2) - (height / 2));
     }
     window.open(
-      'https://www.facebook.com/sharer.php?s=100&p[url]=' + encodeURIComponent(shareUrl),
+      'https://www.facebook.com/sharer.php?u[url]=' + encodeURIComponent(shareUrl),
       'sharer',
       windowOptions + ',width=' + width + ',height=' + height + ',left=' + left + ',top=' + top
     );


### PR DESCRIPTION
Referred to issue #1431 