### PR TITLE
Add single quotes to background-image property

### DIFF
--- a/lib/ext/ui.js
+++ b/lib/ext/ui.js
@@ -453,7 +453,7 @@ flowplayer(function(api, root) {
    });
 
    // poster -> background image
-   if (conf.poster) common.css(root, 'background-image', "url(" + conf.poster + ")");
+   if (conf.poster) common.css(root, 'background-image', "url('" + conf.poster + "')");
 
    var bc = common.css(root, 'background-color'),
       has_bg = common.css(root, 'background-image') != "none" || bc && bc != "rgba(0, 0, 0, 0)" && bc != "transparent";


### PR DESCRIPTION
If you have a poster/image URL that contains a closing bracket `)` it won't be set as the background-image property as it closes the `url()` property early.

I have added single quotes the same as is already done a few lines below
https://github.com/flowplayer/flowplayer/blob/d5b70e7a40518582287d9b73aa76ea568c948816/lib/ext/ui.js#L485

An example of a url that does not currently work is.

https://d17m69v0nrxktd.cloudfront.net/ce2jJLeNlNb8Be2zqQahAm8tV98=/1170x656/filters:quality(60)/video_thumbnails/2140/593fa756586e5_0016.jpg